### PR TITLE
Fixes outstanding broken unit tests from technical uplift.

### DIFF
--- a/webcurator-core/src/test/java/org/webcurator/core/harvester/coordinator/MockHarvestAgentManager.java
+++ b/webcurator-core/src/test/java/org/webcurator/core/harvester/coordinator/MockHarvestAgentManager.java
@@ -1,0 +1,453 @@
+package org.webcurator.core.harvester.coordinator;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.webcurator.core.common.Environment;
+import org.webcurator.core.common.EnvironmentFactory;
+import org.webcurator.core.harvester.agent.HarvestAgent;
+import org.webcurator.core.harvester.agent.HarvestAgentFactory;
+import org.webcurator.core.reader.LogReader;
+import org.webcurator.core.scheduler.TargetInstanceManager;
+import org.webcurator.domain.TargetInstanceDAO;
+import org.webcurator.domain.model.core.HarvesterStatus;
+import org.webcurator.domain.model.core.TargetInstance;
+import org.webcurator.domain.model.core.harvester.agent.HarvestAgentStatusDTO;
+import org.webcurator.domain.model.core.harvester.agent.HarvesterStatusDTO;
+
+import java.text.MessageFormat;
+import java.util.*;
+
+public class MockHarvestAgentManager implements HarvestAgentManager {
+
+	static Set<Long> targetInstanceLocks = Collections.synchronizedSet(new HashSet<Long>());
+
+	HashMap<String, HarvestAgentStatusDTO> harvestAgents = new HashMap<String, HarvestAgentStatusDTO>();;
+	private Logger log = LoggerFactory.getLogger(getClass());
+	private TargetInstanceDAO targetInstanceDao;
+	private TargetInstanceManager targetInstanceManager;
+	private HarvestAgentFactory harvestAgentFactory;
+
+	@Override
+	public void heartbeat(HarvestAgentStatusDTO aStatus) {
+		if (harvestAgents.containsKey(aStatus.getName())) {
+			log.debug("Updating status for {}", aStatus.getName());
+		} else {
+			log.info("Registering harvest agent " + aStatus.getName());
+		}
+
+		aStatus.setLastUpdated(new Date());
+		HarvestAgentStatusDTO currentStatus = harvestAgents.get(aStatus.getName());
+		if (currentStatus != null) {
+			aStatus.setAcceptTasks(currentStatus.isAcceptTasks());
+		}
+		harvestAgents.put(aStatus.getName(), aStatus);
+
+		HashMap<String, HarvesterStatusDTO> harvesterStatusMap = aStatus.getHarvesterStatus();
+		for (String key : harvesterStatusMap.keySet()) {
+			long tiOid = Long.parseLong(key.substring(key.lastIndexOf("-") + 1));
+
+			// lock the ti for update
+			if (!lock(tiOid))
+				break;
+			log.debug("Obtained lock for ti " + tiOid);
+
+			TargetInstance ti = targetInstanceDao.load(tiOid);
+			HarvesterStatusDTO harvesterStatusDto = (HarvesterStatusDTO) harvesterStatusMap.get(key);
+
+			updateStatusWithEnvironment(harvesterStatusDto);
+			HarvesterStatus harvesterStatus = createHarvesterStatus(ti, harvesterStatusDto);
+
+			String harvesterStatusValue = harvesterStatus.getStatus();
+			if (harvesterStatusValue.startsWith("Paused")) {
+				doHeartbeatPaused(ti);
+			}
+
+			// We have seen cases where a running Harvest is showing as Queued
+			// in the UI. Once in this state, the user has no control over the
+			// harvest and cannot use it. This work around means that any
+			// TIs in the wrong state will be corrected on the next heartbeat
+			if (harvesterStatusValue.startsWith("Running")) {
+				doHeartbeatRunning(aStatus, ti, harvesterStatus);
+			}
+
+			if (harvesterStatusValue.startsWith("Finished")) {
+				doHeartbeatFinished(ti);
+			}
+
+			// This is a required because when a
+			// "Could not launch job - Fatal InitializationException" job occurs
+			// We do not get a notification that causes the job to stop nicely
+			if (harvesterStatusValue.startsWith("Could not launch job - Fatal InitializationException")) {
+				doHeartbeatLaunchFailed(ti);
+			}
+
+			targetInstanceManager.save(ti);
+			unLock(tiOid);
+			log.debug("Released lock for ti " + tiOid);
+		}
+	}
+
+	private HarvesterStatus createHarvesterStatus(TargetInstance ti, HarvesterStatusDTO harvesterStatusDto) {
+		HarvesterStatus harvesterStatus = null;
+		if (ti.getStatus() == null) {
+			harvesterStatus = new HarvesterStatus(harvesterStatusDto);
+			ti.setStatus(harvesterStatus);
+			harvesterStatus.setOid(ti.getOid());
+		} else {
+			harvesterStatus = ti.getStatus();
+			harvesterStatus.update(harvesterStatusDto);
+		}
+		return harvesterStatus;
+	}
+
+	private void updateStatusWithEnvironment(HarvesterStatusDTO harvesterStatusDto) {
+		// Mock stub
+	}
+
+	private void doHeartbeatLaunchFailed(TargetInstance ti) {
+		String state = ti.getState();
+		if (state.equals(TargetInstance.STATE_RUNNING)) {
+			ti.setState(TargetInstance.STATE_ABORTED);
+			HarvestAgentStatusDTO hs = getHarvestAgentStatusFor(ti.getJobName());
+			if (hs == null) {
+				log.warn("Forced Abort Failed. Failed to find the Harvest Agent for the Job {}.", ti.getJobName());
+			} else {
+				HarvestAgent agent = harvestAgentFactory.getHarvestAgent(hs);
+				agent.abort(ti.getJobName());
+			}
+		}
+	}
+
+	private void doHeartbeatFinished(TargetInstance ti) {
+		String state = ti.getState();
+		if (state.equals(TargetInstance.STATE_RUNNING)) {
+			ti.setState(TargetInstance.STATE_STOPPING);
+		}
+	}
+
+	private void doHeartbeatRunning(HarvestAgentStatusDTO aStatus, TargetInstance ti, HarvesterStatus harvesterStatus) {
+		String state = ti.getState();
+		if (state.equals(TargetInstance.STATE_PAUSED) || state.equals(TargetInstance.STATE_QUEUED)) {
+
+			if (state.equals(TargetInstance.STATE_QUEUED)) {
+				log.info("HarvestCoordinator: Target Instance state changed from Queued to Running for target instance {}", ti
+						.getOid().toString());
+			}
+			if (ti.getActualStartTime() == null) {
+				// This was not set up correctly when harvest was initiated
+				Date now = new Date();
+				Date startTime = new Date(now.getTime() - harvesterStatus.getElapsedTime());
+				ti.setActualStartTime(startTime);
+				ti.setHarvestServer(aStatus.getName());
+
+				log.info("HarvestCoordinator: Target Instance start time set for target instance " + ti.getOid().toString());
+			}
+			ti.setState(TargetInstance.STATE_RUNNING);
+		}
+	}
+
+	private void doHeartbeatPaused(TargetInstance ti) {
+		String state = ti.getState();
+		if (state.equals(TargetInstance.STATE_RUNNING)) {
+			ti.setState(TargetInstance.STATE_PAUSED);
+		}
+	}
+
+	/**
+	 * @return a harvest agent status for the specified job name
+	 */
+	HarvestAgentStatusDTO getHarvestAgentStatusFor(String aJobName) {
+		for (HarvestAgentStatusDTO agentStatus : harvestAgents.values()) {
+			if (agentStatus.getHarvesterStatus() != null) {
+				if (agentHasJob(aJobName, agentStatus))
+					return agentStatus;
+			}
+		}
+		return null;
+	}
+
+	boolean agentHasJob(String aJobName, HarvestAgentStatusDTO agentStatus) {
+		for (Object hsObject : agentStatus.getHarvesterStatus().values()) {
+			HarvesterStatusDTO harvesterStatus = (HarvesterStatusDTO) hsObject;
+			if (harvesterStatus.getJobName().equals(aJobName)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public void updateProfileOverrides(TargetInstance aTargetInstance, String profileString) {
+		HarvestAgentStatusDTO status = getHarvestAgentStatusFor(aTargetInstance.getJobName());
+		if (status == null) {
+			log.warn("Update Profile Overrides Failed. Failed to find the Harvest Agent for the Job {}.",
+					aTargetInstance.getJobName());
+			return;
+		}
+		HarvestAgent agent = harvestAgentFactory.getHarvestAgent(status);
+		agent.updateProfileOverrides(aTargetInstance.getJobName(), profileString);
+	}
+
+	@Override
+	public void pause(TargetInstance aTargetInstance) {
+		String jobName = aTargetInstance.getJobName();
+		HarvestAgentStatusDTO status = getHarvestAgentStatusFor(jobName);
+		if (status == null) {
+			log.warn("PAUSE Failed. Failed to find the Harvest Agent for the Job {}.", jobName);
+			return;
+		}
+
+		HarvestAgent agent = harvestAgentFactory.getHarvestAgent(status);
+
+		// Update the state of the allocated Target Instance
+		aTargetInstance.setState(TargetInstance.STATE_PAUSED);
+		// Note that resume uses a different method to save the target instance!
+		targetInstanceDao.save(aTargetInstance);
+
+		agent.pause(jobName);
+	}
+
+	@Override
+	public void resume(TargetInstance aTargetInstance) {
+		HarvestAgentStatusDTO status = getHarvestAgentStatusFor(aTargetInstance.getJobName());
+		if (status == null) {
+			log.warn("RESUME Failed. Failed to find the Harvest Agent for the Job {}.", aTargetInstance.getJobName());
+			return;
+		}
+		HarvestAgent agent = harvestAgentFactory.getHarvestAgent(status);
+
+		// Update the state of the allocated Target Instance
+		aTargetInstance.setState(TargetInstance.STATE_RUNNING);
+		// Note that pause uses a different method to save the target instance!
+		targetInstanceManager.save(aTargetInstance);
+
+		agent.resume(aTargetInstance.getJobName());
+	}
+
+	@Override
+	public void abort(TargetInstance aTargetInstance) {
+		// Update the state of the allocated Target Instance
+		aTargetInstance.setState(TargetInstance.STATE_ABORTED);
+		targetInstanceDao.save(aTargetInstance);
+
+		HarvestAgentStatusDTO status = getHarvestAgentStatusFor(aTargetInstance.getJobName());
+		if (status == null) {
+			log.warn("ABORT Failed. Failed to find the Harvest Agent for the Job {}.", aTargetInstance.getJobName());
+		} else {
+			HarvestAgent agent = harvestAgentFactory.getHarvestAgent(status);
+			try {
+				agent.abort(aTargetInstance.getJobName());
+			} catch (RuntimeException e) {
+				log.warn("ABORT Failed. Failed Abort the Job {} on the Harvest Agent {}.", aTargetInstance.getJobName(),
+						agent.getName());
+			}
+		}
+	}
+
+	@Override
+	public void stop(TargetInstance aTargetInstance) {
+		HarvestAgentStatusDTO status = getHarvestAgentStatusFor(aTargetInstance.getJobName());
+		if (status == null) {
+			log.warn("STOP Failed. Failed to find the Harvest Agent for the Job {}.", aTargetInstance.getJobName());
+			return;
+		}
+		HarvestAgent agent = harvestAgentFactory.getHarvestAgent(status);
+
+		agent.stop(aTargetInstance.getJobName());
+	}
+
+	@Override
+	public void pauseAll() {
+		for (HarvestAgentStatusDTO agentDTO : harvestAgents.values()) {
+			if (agentDTO.getHarvesterStatus() != null && !agentDTO.getHarvesterStatus().isEmpty()) {
+				HarvestAgent agent = harvestAgentFactory.getHarvestAgent(agentDTO);
+				agent.pauseAll();
+			}
+		}
+	}
+
+	@Override
+	public void resumeAll() {
+		for (HarvestAgentStatusDTO agentDTO : harvestAgents.values()) {
+			if (agentDTO.getHarvesterStatus() != null && !agentDTO.getHarvesterStatus().isEmpty()) {
+				HarvestAgent agent = harvestAgentFactory.getHarvestAgent(agentDTO);
+				agent.resumeAll();
+			}
+		}
+	}
+
+	@Override
+	public LogReader getLogReader(TargetInstance aTargetInstance) {
+		// If we are harvesting then get the log files from the harvester
+		HarvestAgentStatusDTO status = getHarvestAgentStatusFor(aTargetInstance.getJobName());
+		if (status == null) {
+			log.warn("list Log Files Failed. Failed to find the Log Reader for the Job {}.", aTargetInstance.getJobName());
+			return null;
+		}
+
+		LogReader logReader = harvestAgentFactory.getLogReader(status);
+		return logReader;
+	}
+
+	@Override
+	public void pauseAgent(String agentName) {
+		HarvestAgentStatusDTO agent = harvestAgents.get(agentName);
+		if (agent != null) {
+			agent.setAcceptTasks(false);
+		}
+	}
+
+	@Override
+	public void resumeAgent(String agentName) {
+		HarvestAgentStatusDTO agent = harvestAgents.get(agentName);
+		if (agent != null) {
+			agent.setAcceptTasks(true);
+		}
+	}
+
+	@Override
+	public boolean runningOrPaused(TargetInstance aTargetInstance) {
+		String state = aTargetInstance.getState();
+		return state.equals(TargetInstance.STATE_RUNNING) || aTargetInstance.getState().equals(TargetInstance.STATE_PAUSED);
+	}
+
+	@Override
+	public void restrictBandwidthFor(TargetInstance targetInstance) {
+		HarvestAgentStatusDTO ha = getHarvestAgentStatusFor(targetInstance.getJobName());
+		if (ha != null) {
+			HarvestAgent agent = harvestAgentFactory.getHarvestAgent(ha);
+			Long allocated = targetInstance.getAllocatedBandwidth();
+			if (allocated == null || targetInstance.getAllocatedBandwidth().intValue() <= 0) {
+				// zero signifies unlimited bandwidth, prevent this
+				targetInstance.setAllocatedBandwidth(new Long(1));
+			}
+			agent.restrictBandwidth(targetInstance.getJobName(), targetInstance.getAllocatedBandwidth().intValue());
+			targetInstanceDao.save(targetInstance);
+		}
+	}
+
+	@Override
+	public List<HarvestAgentStatusDTO> getHarvestersForAgency(String agencyName) {
+		List<HarvestAgentStatusDTO> result = new ArrayList<HarvestAgentStatusDTO>();
+		for (HarvestAgentStatusDTO agent : harvestAgents.values()) {
+			ArrayList<String> allowedAgencies = agent.getAllowedAgencies();
+			if (allowedAgencies == null || allowedAgencies.isEmpty() || allowedAgencies.contains(agencyName)) {
+				result.add(agent);
+			}
+		}
+		return result;
+	}
+
+	@Override
+	public void markDead(HarvestAgentStatusDTO agent) {
+		harvestAgents.remove(agent.getName());
+	}
+
+	@Override
+	public void initiateHarvest(HarvestAgentStatusDTO aHarvestAgent, TargetInstance aTargetInstance, String profile,
+			String seedsString) {
+		HarvestAgent agent = harvestAgentFactory.getHarvestAgent(aHarvestAgent);
+
+		Map<String, String> params=new HashMap<String, String>();
+		params.put("profile", profile);
+		params.put("seeds", seedsString);
+		agent.initiateHarvest(aTargetInstance.getJobName(), params);
+	}
+
+	@Override
+	public void recoverHarvests(String haScheme, String haHost, int haPort, String haService, List<String> activeJobs){
+		HarvestAgentStatusDTO tempHarvestAgentStatusDTO = new HarvestAgentStatusDTO();
+		tempHarvestAgentStatusDTO.setScheme(haScheme);
+		tempHarvestAgentStatusDTO.setHost(haHost);
+		tempHarvestAgentStatusDTO.setPort(haPort);
+		HarvestAgent agent  = harvestAgentFactory.getHarvestAgent(tempHarvestAgentStatusDTO);
+		agent.recoverHarvests(activeJobs);
+	}
+
+	@Override
+	public boolean lock(Long tiOid) {
+		return targetInstanceLocks.add(tiOid);
+	}
+
+	@Override
+	public void unLock(Long tiOid) {
+		targetInstanceLocks.remove(tiOid);
+	}
+
+	@Override
+	public HashMap<String, HarvestAgentStatusDTO> getHarvestAgents() {
+		return new HashMap<String, HarvestAgentStatusDTO>(harvestAgents);
+	}
+
+	public void setTargetInstanceManager(TargetInstanceManager targetInstanceManager) {
+		this.targetInstanceManager = targetInstanceManager;
+	}
+
+	public void setHarvestAgentFactory(HarvestAgentFactory harvestAgentFactory) {
+		this.harvestAgentFactory = harvestAgentFactory;
+	}
+
+	public void setTargetInstanceDao(TargetInstanceDAO targetInstanceDao) {
+		this.targetInstanceDao = targetInstanceDao;
+	}
+
+	@Override
+	public void purgeAbortedTargetInstances(List<String> tiNames) {
+		for(HarvestAgentStatusDTO statusDto:harvestAgents.values()) {
+			HarvestAgent ha = harvestAgentFactory.getHarvestAgent(statusDto);
+			try {
+				ha.purgeAbortedTargetInstances(tiNames);
+			} catch (Exception e) {
+				log.error(MessageFormat.format("Failed to complete the purge of aborted ti data via HA: {0}", e.getMessage()), e);
+			}
+		}
+	}
+
+	@Override
+	public List<HarvestAgentStatusDTO> getAvailableHarvesters(String agencyName) {
+		List<HarvestAgentStatusDTO> result = new ArrayList<HarvestAgentStatusDTO>();
+		List<HarvestAgentStatusDTO> harvestersForAgency = getHarvestersForAgency(agencyName);
+		for (HarvestAgentStatusDTO agent : harvestersForAgency) {
+			if (harvesterCanHarvestNow(agent)) {
+				result.add(agent);
+			}
+		}
+		Collections.sort(result, new Comparator<HarvestAgentStatusDTO>() {
+			@Override
+			public int compare(HarvestAgentStatusDTO o1, HarvestAgentStatusDTO o2) {
+				// Result is negated to get a descending sort order
+				return -(o1.getHarvesterStatusCount() - o2.getHarvesterStatusCount());
+			}
+		});
+		return result;
+	}
+
+	/**
+	 * Return the next harvest agent to allocate a target instance to.
+	 * 
+	 * @param agencyName
+	 *            the agency to get harvesters for
+	 * @param harvesterType
+	 *            the desired harvester type
+	 * @return the harvest agent
+	 */
+	@Override
+	public HarvestAgentStatusDTO getHarvester(String agencyName, String harvesterType) {
+		HarvestAgentStatusDTO selectedAgent = null;
+
+		List<HarvestAgentStatusDTO> harvestersForAgency = getHarvestersForAgency(agencyName);
+		for (HarvestAgentStatusDTO agent : harvestersForAgency) {
+			if (selectedAgent == null || agent.getHarvesterStatusCount() < selectedAgent.getHarvesterStatusCount()) {
+				if (harvesterCanHarvestNow(agent) && agent.getHarvesterType().equals(harvesterType)) {
+					selectedAgent = agent;
+				}
+			}
+		}
+		return selectedAgent;
+	}
+
+	private boolean harvesterCanHarvestNow(HarvestAgentStatusDTO agent) {
+		return !agent.getMemoryWarning() && !agent.isInTransition() && agent.getHarvesterStatusCount() < agent.getMaxHarvests();
+	}
+
+}

--- a/webcurator-webapp/src/main/java/org/webcurator/ui/target/controller/AddParentsController.java
+++ b/webcurator-webapp/src/main/java/org/webcurator/ui/target/controller/AddParentsController.java
@@ -28,9 +28,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.stereotype.Controller;
 import org.springframework.validation.BindingResult;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.ModelAndView;
@@ -69,7 +67,7 @@ public class AddParentsController {
 	private String subGroupSeparator;
 
 	@Autowired
-	private AddParentsValidator validator;
+	private AddParentsValidator addParentsValidator;
 
 	/** Default COnstructor. */
 	public AddParentsController() {
@@ -130,7 +128,7 @@ public class AddParentsController {
 	protected ModelAndView handle(@ModelAttribute("addParentsCommand") AddParentsCommand command,
                                   BindingResult bindingResult,
 								  HttpServletRequest request, HttpServletResponse response) throws Exception {
-		validator.validate(command, bindingResult);
+		addParentsValidator.validate(command, bindingResult);
 		Target target = getEditorContext(request).getTarget();
 
 		if( AddParentsCommand.ACTION_ADD_PARENTS.equals(command.getActionCmd()))

--- a/webcurator-webapp/src/main/java/org/webcurator/ui/target/controller/HarvestNowController.java
+++ b/webcurator-webapp/src/main/java/org/webcurator/ui/target/controller/HarvestNowController.java
@@ -31,7 +31,6 @@ import org.springframework.context.annotation.Scope;
 import org.springframework.orm.hibernate5.HibernateOptimisticLockingFailureException;
 import org.springframework.stereotype.Controller;
 import org.springframework.validation.BindingResult;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -69,7 +68,7 @@ public class HarvestNowController {
     private Log log;
 
     @Autowired
-    private HarvestNowValidator validator;
+    private HarvestNowValidator harvestNowValidator;
 
     /**
      * Constructor to set the command class for this controller.
@@ -92,7 +91,7 @@ public class HarvestNowController {
     protected ModelAndView processFormSubmission(@ModelAttribute("targetInstanceCommand") TargetInstanceCommand cmd,
                                                  BindingResult bindingResult, HttpServletRequest aReq)
             throws Exception {
-        validator.validate(cmd, bindingResult);
+        harvestNowValidator.validate(cmd, bindingResult);
     	if (!cmd.getCmd().equals(TargetInstanceCommand.ACTION_HARVEST)) {
             aReq.getSession().removeAttribute(TargetInstanceCommand.SESSION_TI);
             return new ModelAndView("redirect:/" + Constants.CNTRL_TI_QUEUE);

--- a/webcurator-webapp/src/main/java/org/webcurator/ui/target/controller/LogReaderController.java
+++ b/webcurator-webapp/src/main/java/org/webcurator/ui/target/controller/LogReaderController.java
@@ -24,7 +24,6 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Controller;
 import org.springframework.validation.BindingResult;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.ModelAndView;
 import org.webcurator.core.harvester.coordinator.HarvestCoordinator;
@@ -52,7 +51,7 @@ public class LogReaderController {
 
 	@Autowired
     @Qualifier("logReaderValidator")
-	private LogReaderValidator validator;
+	private LogReaderValidator logReaderValidator;
 
 	public LogReaderController() {
 		//Add values in reverse order of display
@@ -79,7 +78,7 @@ public class LogReaderController {
 	@RequestMapping(path = "/curator/target/log-viewer.html", method = {RequestMethod.POST, RequestMethod.GET})
 	protected ModelAndView handle(@ModelAttribute("logReaderCommand") LogReaderCommand cmd,
                                   BindingResult bindingResult) throws Exception {
-		validator.validate(cmd, bindingResult);
+		logReaderValidator.validate(cmd, bindingResult);
 		String messageText = "";
 		int firstLine = 0;
 		List<String> lines = Arrays.asList("", "");

--- a/webcurator-webapp/src/main/java/org/webcurator/ui/target/controller/TargetInstanceResultHandler.java
+++ b/webcurator-webapp/src/main/java/org/webcurator/ui/target/controller/TargetInstanceResultHandler.java
@@ -33,6 +33,7 @@ import org.springframework.web.servlet.ModelAndView;
 import org.webcurator.core.agency.AgencyUserManager;
 import org.webcurator.core.exceptions.WCTRuntimeException;
 import org.webcurator.core.harvester.coordinator.HarvestCoordinator;
+import org.webcurator.core.notification.InTrayManager;
 import org.webcurator.core.notification.InTrayManagerImpl;
 import org.webcurator.core.scheduler.TargetInstanceManager;
 import org.webcurator.core.store.DigitalAssetStore;
@@ -59,6 +60,10 @@ public class TargetInstanceResultHandler extends TabHandler {
     private HarvestCoordinator harvestCoordinator;
     /** the digital asset store containing the harvests. */
     private DigitalAssetStore digitalAssetStore = null;
+
+    private DigitalAssetStoreClient digitalAssetStoreClient = null;
+
+	private InTrayManagerImpl inTrayManager = null;
 
     private AgencyUserManager agencyUserManager;
 
@@ -334,9 +339,9 @@ public class TargetInstanceResultHandler extends TabHandler {
 					String customDepositFormURL = response.getUrlForCustomDepositForm();
 
 					// Will be needed to access the Rosetta interface
-					ApplicationContext ctx=ApplicationContextFactory.getApplicationContext();
-					DigitalAssetStoreClient dasClient=ctx.getBean(DigitalAssetStoreClient.class);
-					InTrayManagerImpl inTrayManager = ctx.getBean(InTrayManagerImpl.class);
+					DigitalAssetStoreClient dasClient = getDASClient();
+					InTrayManagerImpl inTrayManager = getInTrayManager();
+
 
 					req.getSession().setAttribute("dasPort", Integer.toString(dasClient.getPort()));
 					req.getSession().setAttribute("dasHost", dasClient.getHost());
@@ -360,5 +365,21 @@ public class TargetInstanceResultHandler extends TabHandler {
 			}
 		}
 		tmav.addObject("customDepositFormRequired", customDepositFormRequired);
+	}
+
+	private DigitalAssetStoreClient getDASClient(){
+		if(digitalAssetStoreClient == null){
+			ApplicationContext ctx = ApplicationContextFactory.getApplicationContext();
+			digitalAssetStoreClient = ctx.getBean(DigitalAssetStoreClient.class);
+		}
+		return digitalAssetStoreClient;
+	}
+
+	private InTrayManagerImpl getInTrayManager(){
+		if(inTrayManager == null){
+			ApplicationContext ctx = ApplicationContextFactory.getApplicationContext();
+			inTrayManager = ctx.getBean(InTrayManagerImpl.class);
+		}
+		return inTrayManager;
 	}
 }

--- a/webcurator-webapp/src/test/java/org/webcurator/ui/admin/controller/AgencyControllerTest.java
+++ b/webcurator-webapp/src/test/java/org/webcurator/ui/admin/controller/AgencyControllerTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.*;
 
 import java.util.List;
 
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.validation.BindingResult;
 import org.webcurator.test.*;
 
@@ -20,6 +21,7 @@ import org.springframework.context.MockMessageSource;
 import org.webcurator.ui.admin.command.*;
 import org.webcurator.core.agency.*;
 import org.webcurator.domain.model.auth.Agency;
+import org.webcurator.ui.admin.validator.AgencyValidator;
 
 
 /**
@@ -78,13 +80,15 @@ public class AgencyControllerTest extends BaseWCTTest<AgencyController>{
 	public final void testProcessFormSubmission() {
 		try
 		{
-			BindingResult bindingResult = new BindException(new AgencyCommand(), AgencyCommand.ACTION_EDIT);
+			BindingResult bindingResult;
 			testSetAgencyUserManager();
 			testSetMessageSource();
+			ReflectionTestUtils.setField(testInstance, "agencyValidator", new AgencyValidator());
 
 			AgencyCommand aCommand = new AgencyCommand();
 			aCommand.setActionCommand(AgencyCommand.ACTION_NEW);
 			aCommand.setOid(new Long(2000));
+			bindingResult = new BindException(aCommand, AgencyCommand.ACTION_NEW);
 			ModelAndView mav = testInstance.processFormSubmission(aCommand, bindingResult);
 			assertTrue(mav != null);
 			assertTrue(mav.getViewName().equals("newAgency"));
@@ -95,6 +99,8 @@ public class AgencyControllerTest extends BaseWCTTest<AgencyController>{
 			aCommand = new AgencyCommand();
 			aCommand.setActionCommand(AgencyCommand.ACTION_VIEW);
 			aCommand.setOid(new Long(2000));
+			aCommand.setViewOnlyMode(true);
+			bindingResult = new BindException(aCommand, AgencyCommand.ACTION_VIEW);
 			mav = testInstance.processFormSubmission(aCommand, bindingResult);
 			assertTrue(mav != null);
 			assertTrue(mav.getViewName().equals("newAgency"));
@@ -108,6 +114,7 @@ public class AgencyControllerTest extends BaseWCTTest<AgencyController>{
 			aCommand = new AgencyCommand();
 			aCommand.setActionCommand(AgencyCommand.ACTION_EDIT);
 			aCommand.setOid(new Long(2000));
+			bindingResult = new BindException(aCommand, AgencyCommand.ACTION_EDIT);
 			mav = testInstance.processFormSubmission(aCommand, bindingResult);
 			assertTrue(mav != null);
 			assertTrue(mav.getViewName().equals("newAgency"));
@@ -121,6 +128,8 @@ public class AgencyControllerTest extends BaseWCTTest<AgencyController>{
 			aCommand = new AgencyCommand();
 			aCommand.setActionCommand(AgencyCommand.ACTION_SAVE);
 			aCommand.setName("New Test Agency");
+			aCommand.setAddress("The Agency address");
+			bindingResult = new BindException(aCommand, AgencyCommand.ACTION_SAVE);
 			mav = testInstance.processFormSubmission(aCommand, bindingResult);
 			assertTrue(mav != null);
 			assertTrue(mav.getViewName().equals("viewAgencies"));

--- a/webcurator-webapp/src/test/java/org/webcurator/ui/admin/controller/ChangePasswordControllerTest.java
+++ b/webcurator-webapp/src/test/java/org/webcurator/ui/admin/controller/ChangePasswordControllerTest.java
@@ -9,6 +9,7 @@ import org.springframework.context.MockMessageSource;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.ServletRequestDataBinder;
@@ -20,6 +21,7 @@ import org.webcurator.core.agency.MockAgencyUserManagerImpl;
 import org.webcurator.domain.model.auth.Agency;
 import org.webcurator.test.BaseWCTTest;
 import org.webcurator.ui.admin.command.*;
+import org.webcurator.ui.admin.validator.ChangePasswordValidator;
 
 public class ChangePasswordControllerTest extends BaseWCTTest<ChangePasswordController>{
 
@@ -69,11 +71,12 @@ public class ChangePasswordControllerTest extends BaseWCTTest<ChangePasswordCont
 	@Test
 	public final void testProcessFormSubmission() {
 		MockHttpServletRequest request = new MockHttpServletRequest();
-        BindingResult bindingResult = new BindException(new CreateUserCommand(), CreateUserCommand.ACTION_EDIT);
+        BindingResult bindingResult;
 		testSetAgencyUserManager();
 		testSetAuthorityManager();
 		testSetMessageSource();
 		testSetEncoder();
+		ReflectionTestUtils.setField(testInstance, "changePasswordValidator", new ChangePasswordValidator());
 
 		try
 		{
@@ -82,6 +85,7 @@ public class ChangePasswordControllerTest extends BaseWCTTest<ChangePasswordCont
 			aCommand.setUserOid(1000L);
 			aCommand.setNewPwd("Pa55word");
 			aCommand.setConfirmPwd("Pa55word");
+			bindingResult = new BindException(aCommand, CreateUserCommand.ACTION_SAVE);
 			ModelAndView mav = testInstance.processFormSubmission(request, aCommand, bindingResult);
 			assertTrue(mav != null);
 			assertTrue(mav.getViewName().equals("viewUsers"));

--- a/webcurator-webapp/src/test/java/org/webcurator/ui/admin/controller/CreateUserControllerTest.java
+++ b/webcurator-webapp/src/test/java/org/webcurator/ui/admin/controller/CreateUserControllerTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import org.springframework.mock.web.*;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.ServletRequestDataBinder;
 import org.springframework.validation.BindException;
@@ -17,6 +18,7 @@ import org.webcurator.ui.admin.command.*;
 import org.webcurator.core.agency.*;
 import org.webcurator.auth.*;
 import org.webcurator.domain.model.auth.*;
+import org.webcurator.ui.admin.validator.CreateUserValidator;
 
 import java.util.List;
 
@@ -54,14 +56,16 @@ public class CreateUserControllerTest extends BaseWCTTest<CreateUserController>{
 		try
 		{
 			MockHttpServletRequest request = new MockHttpServletRequest();
-			BindingResult bindingResult = new BindException(new CreateUserCommand(), CreateUserCommand.ACTION_EDIT);
+			BindingResult bindingResult;
 			testSetAgencyUserManager();
 			testSetAuthorityManager();
 			testSetMessageSource();
 			testSetPasswordEncoder();
+			ReflectionTestUtils.setField(testInstance, "createUserValidator", new CreateUserValidator());
 
 			CreateUserCommand aCommand = new CreateUserCommand();
 			aCommand.setAction(CreateUserCommand.ACTION_NEW);
+			bindingResult = new BindException(aCommand, CreateUserCommand.ACTION_NEW);
 			ModelAndView mav = testInstance.processFormSubmission(request, aCommand, bindingResult);
 			assertTrue(mav != null);
 			assertTrue(mav.getViewName().equals("newUser"));
@@ -69,6 +73,7 @@ public class CreateUserControllerTest extends BaseWCTTest<CreateUserController>{
 			aCommand = new CreateUserCommand();
 			aCommand.setAction(CreateUserCommand.ACTION_VIEW);
 			aCommand.setOid(new Long(1000));
+			bindingResult = new BindException(aCommand, CreateUserCommand.ACTION_VIEW);
 			mav = testInstance.processFormSubmission(request, aCommand, bindingResult);
 			assertTrue(mav != null);
 			assertTrue(mav.getViewName().equals("newUser"));
@@ -79,6 +84,7 @@ public class CreateUserControllerTest extends BaseWCTTest<CreateUserController>{
 			aCommand = new CreateUserCommand();
 			aCommand.setAction(CreateUserCommand.ACTION_EDIT);
 			aCommand.setOid(new Long(1000));
+			bindingResult = new BindException(aCommand, CreateUserCommand.ACTION_EDIT);
 			mav = testInstance.processFormSubmission(request, aCommand, bindingResult);
 			assertTrue(mav != null);
 			assertTrue(mav.getViewName().equals("newUser"));
@@ -89,9 +95,12 @@ public class CreateUserControllerTest extends BaseWCTTest<CreateUserController>{
 			aCommand = new CreateUserCommand();
 			aCommand.setAction(CreateUserCommand.ACTION_SAVE);
 			aCommand.setOid(1000L);
+			aCommand.setAgencyOid(1000L);
 			aCommand.setFirstname("Test");
 			aCommand.setLastname("User");
 			aCommand.setUsername("TestUserName");
+			aCommand.setEmail("testuser@test.com");
+			bindingResult = new BindException(aCommand, CreateUserCommand.ACTION_SAVE);
 			mav = testInstance.processFormSubmission(request, aCommand, bindingResult);
 			assertTrue(mav != null);
 			assertTrue(mav.getViewName().equals("viewUsers"));
@@ -104,10 +113,14 @@ public class CreateUserControllerTest extends BaseWCTTest<CreateUserController>{
 
 			aCommand = new CreateUserCommand();
 			aCommand.setAction(CreateUserCommand.ACTION_SAVE);
+			aCommand.setAgencyOid(2000L);
 			aCommand.setFirstname("Test");
 			aCommand.setLastname("User");
 			aCommand.setUsername("TestUserName");
-			aCommand.setPassword("Password");
+			aCommand.setPassword("Password01");
+			aCommand.setConfirmPassword("Password01");
+			aCommand.setEmail("testuser@test.com");
+			bindingResult = new BindException(aCommand, CreateUserCommand.ACTION_SAVE);
 			mav = testInstance.processFormSubmission(request, aCommand, bindingResult);
 			assertTrue(mav != null);
 			assertTrue(mav.getViewName().equals("viewUsers"));

--- a/webcurator-webapp/src/test/java/org/webcurator/ui/admin/controller/RoleControllerTest.java
+++ b/webcurator-webapp/src/test/java/org/webcurator/ui/admin/controller/RoleControllerTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.*;
 
 import org.junit.Test;
 import org.springframework.mock.web.*;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.ServletRequestDataBinder;
 import org.springframework.validation.BindException;
@@ -22,7 +23,7 @@ import javax.management.relation.Role;
 
 import org.webcurator.core.util.AuthUtil;
 import org.webcurator.domain.model.auth.Agency;
-
+import org.webcurator.ui.admin.validator.RoleValidator;
 
 
 public class RoleControllerTest extends BaseWCTTest<RoleController> {
@@ -111,14 +112,16 @@ public class RoleControllerTest extends BaseWCTTest<RoleController> {
 		try
 		{
 			MockHttpServletRequest request = new MockHttpServletRequest();
-            BindingResult bindingResult = new BindException(new RoleCommand(), RoleCommand.ACTION_EDIT);
+            BindingResult bindingResult;
 			this.testSetAgencyUserManager();
 			this.testSetAuthorityManager();
 			this.testSetMessageSource();
+			ReflectionTestUtils.setField(testInstance, "roleValidator", new RoleValidator());
 
 			RoleCommand aCommand = new RoleCommand();
 			aCommand.setAction(RoleCommand.ACTION_NEW);
 			aCommand.setOid(new Long(3000));
+			bindingResult = new BindException(aCommand, RoleCommand.ACTION_NEW);
 			ModelAndView mav = testInstance.processFormSubmission(request, aCommand, bindingResult);
 			assertTrue(mav != null);
 			assertTrue(mav.getViewName().equals("AddRole"));
@@ -129,6 +132,7 @@ public class RoleControllerTest extends BaseWCTTest<RoleController> {
 			aCommand = new RoleCommand();
 			aCommand.setAction(RoleCommand.ACTION_VIEW);
 			aCommand.setOid(new Long(3000));
+			bindingResult = new BindException(aCommand, RoleCommand.ACTION_VIEW);
 			mav = testInstance.processFormSubmission(request, aCommand, bindingResult);
 			assertTrue(mav != null);
 			assertTrue(mav.getViewName().equals("AddRole"));
@@ -142,6 +146,7 @@ public class RoleControllerTest extends BaseWCTTest<RoleController> {
 			aCommand = new RoleCommand();
 			aCommand.setAction(RoleCommand.ACTION_EDIT);
 			aCommand.setOid(new Long(3000));
+			bindingResult = new BindException(aCommand, RoleCommand.ACTION_EDIT);
 			mav = testInstance.processFormSubmission(request, aCommand, bindingResult);
 			assertTrue(mav != null);
 			assertTrue(mav.getViewName().equals("AddRole"));
@@ -155,9 +160,11 @@ public class RoleControllerTest extends BaseWCTTest<RoleController> {
 			aCommand = new RoleCommand();
 			aCommand.setAction(RoleCommand.ACTION_SAVE);
 			aCommand.setRoleName("New Test Role");
+			aCommand.setDescription("A new role for testing");
 			aCommand.setAgency(AuthUtil.getRemoteUserObject().getAgency().getOid());
 			String[] scopedPrivileges = {};
 			aCommand.setScopedPrivileges(scopedPrivileges);
+			bindingResult = new BindException(aCommand, RoleCommand.ACTION_SAVE);
 			mav = testInstance.processFormSubmission(request, aCommand, bindingResult);
 			assertTrue(mav != null);
 			assertTrue(mav.getViewName().equals("Roles"));
@@ -169,6 +176,7 @@ public class RoleControllerTest extends BaseWCTTest<RoleController> {
 			aCommand.setAction(RoleCommand.ACTION_FILTER);
 			String agencyFilter = "Dummy";
 			aCommand.setAgencyFilter(agencyFilter);
+			bindingResult = new BindException(aCommand, RoleCommand.ACTION_FILTER);
 			mav = testInstance.processFormSubmission(request, aCommand, bindingResult);
 			assertTrue(mav != null);
 			assertTrue(mav.getViewName().equals("Roles"));

--- a/webcurator-webapp/src/test/java/org/webcurator/ui/admin/controller/TemplateControllerTest.java
+++ b/webcurator-webapp/src/test/java/org/webcurator/ui/admin/controller/TemplateControllerTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.*;
 
 import org.junit.Test;
 import org.springframework.context.MockMessageSource;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.servlet.ModelAndView;
@@ -15,6 +16,7 @@ import org.webcurator.core.admin.PermissionTemplateManagerImpl;
 import org.webcurator.core.agency.*;
 import org.webcurator.domain.MockPermissionTemplateDAO;
 import org.webcurator.domain.MockUserRoleDAO;
+import org.webcurator.ui.admin.validator.TemplateValidator;
 
 public class TemplateControllerTest extends BaseWCTTest<TemplateController> {
 
@@ -33,6 +35,7 @@ public class TemplateControllerTest extends BaseWCTTest<TemplateController> {
 
 		TemplateCommand aCmd = setUpCommand(action, 1);
         BindingResult bindingResult = new BindException(aCmd, action);
+		ReflectionTestUtils.setField(testInstance, "templateValidator", new TemplateValidator());
 
 		try
 		{
@@ -80,6 +83,7 @@ public class TemplateControllerTest extends BaseWCTTest<TemplateController> {
 
 		TemplateCommand aCmd = setUpCommand(action, 0);
         BindingResult bindingResult = new BindException(aCmd, action);
+		ReflectionTestUtils.setField(testInstance, "templateValidator", new TemplateValidator());
 
 		try
 		{
@@ -101,6 +105,7 @@ public class TemplateControllerTest extends BaseWCTTest<TemplateController> {
 
 		TemplateCommand aCmd = setUpCommand(action, 1);
         BindingResult bindingResult = new BindException(aCmd, action);
+		ReflectionTestUtils.setField(testInstance, "templateValidator", new TemplateValidator());
 
 		try
 		{
@@ -120,7 +125,12 @@ public class TemplateControllerTest extends BaseWCTTest<TemplateController> {
 		setUpController();
 
 		TemplateCommand aCmd = setUpCommand(action, 1);
+		aCmd.setAgencyOid(1000L);
+		aCmd.setTemplateName("A test print template");
+		aCmd.setTemplateType("Print Template");
+		aCmd.setTemplateText("A test template with text.");
         BindingResult bindingResult = new BindException(aCmd, action);
+		ReflectionTestUtils.setField(testInstance, "templateValidator", new TemplateValidator());
 
 		try
 		{

--- a/webcurator-webapp/src/test/java/org/webcurator/ui/archive/ArchiveControllerTest.java
+++ b/webcurator-webapp/src/test/java/org/webcurator/ui/archive/ArchiveControllerTest.java
@@ -7,8 +7,10 @@ import java.util.*;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
+import org.webcurator.domain.model.core.ArcHarvestResult;
 import org.webcurator.test.BaseWCTTest;
 import org.webcurator.core.archive.*;
 import org.webcurator.core.scheduler.MockTargetInstanceManager;
@@ -45,7 +47,7 @@ public class ArchiveControllerTest extends BaseWCTTest<ArchiveController>{
 			MockHttpServletResponse response = new MockHttpServletResponse();
 
 			List<HarvestResult> harvestResults = new ArrayList<HarvestResult>();
-			HarvestResult hr = new HarvestResult();
+			HarvestResult hr = new ArcHarvestResult();
 			hr.setHarvestNumber(1);
 			harvestResults.add(hr);
 
@@ -109,7 +111,7 @@ public class ArchiveControllerTest extends BaseWCTTest<ArchiveController>{
 			MockHttpServletResponse response = new MockHttpServletResponse();
 
 			List<HarvestResult> harvestResults = new ArrayList<HarvestResult>();
-			HarvestResult hr = new HarvestResult();
+			HarvestResult hr = new ArcHarvestResult();
 			hr.setHarvestNumber(1);
 			harvestResults.add(hr);
 
@@ -140,22 +142,20 @@ public class ArchiveControllerTest extends BaseWCTTest<ArchiveController>{
 
 	@Test
 	public final void testSetArchiveAdapter() {
-
 		archiveAdapter = new MockArchiveAdapter();
-
-		testInstance.setArchiveAdapter(archiveAdapter);
+        ReflectionTestUtils.setField(testInstance, "archiveAdapter", archiveAdapter);
 	}
 
 	@Test
 	public final void testSetTargetInstanceManager() {
 		targetInstanceManager = new MockTargetInstanceManager(testFile);
-		testInstance.setTargetInstanceManager(targetInstanceManager);
+        ReflectionTestUtils.setField(testInstance, "targetInstanceManager", targetInstanceManager);
 	}
 
 	@Test
 	public final void testSetTargetManager() {
 		targetManager = new MockTargetManager(testFile);
-		testInstance.setTargetManager(targetManager);
+        ReflectionTestUtils.setField(testInstance, "targetManager", targetManager);
 	}
 
 	@Test
@@ -173,7 +173,7 @@ public class ArchiveControllerTest extends BaseWCTTest<ArchiveController>{
 	@Test
 	public final void testSetSipBuilder()
 	{
-		testInstance.setSipBuilder(new MockSipBuilder(testFile));
+        ReflectionTestUtils.setField(testInstance, "sipBuilder", new MockSipBuilder(testFile));
 	}
 
 }

--- a/webcurator-webapp/src/test/java/org/webcurator/ui/groups/controller/AddMembersControllerTest.java
+++ b/webcurator-webapp/src/test/java/org/webcurator/ui/groups/controller/AddMembersControllerTest.java
@@ -11,6 +11,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.servlet.ModelAndView;
@@ -102,9 +103,11 @@ public class AddMembersControllerTest extends BaseWCTTest<AddMembersController>{
 	public final void testHandleAddMembers1() {
 		try
 		{
+			BindingResult bindingResult;
 			testSetAuthorityManager();
 			testSetTargetManager();
 			testSetGroupsController();
+			ReflectionTestUtils.setField(testInstance, "addMembersValidator", new AddMembersValidator());
 
 			this.addCurrentUserPrivilege(Privilege.ADD_TARGET_TO_GROUP);
 
@@ -112,14 +115,14 @@ public class AddMembersControllerTest extends BaseWCTTest<AddMembersController>{
 			HttpServletResponse response = new MockHttpServletResponse();
 			AddMembersCommand command = new AddMembersCommand();
 
-            BindingResult bindingResult = new BindException(command, "AddMembersCommand");
-
 			bindEditorContext(request, 15000L);
 
 			command.setActionCmd(AddMembersCommand.ACTION_ADD_MEMBERS);
 			//Already a member of this group
 			long[]  oids = {4000L};
 			command.setMemberOids(oids);
+
+			bindingResult = new BindException(command, "AddMembersCommand");
 
 			assertTrue(testInstance.getEditorContext(request).getTargetGroup().getNewChildren().size() == 0);
 			ModelAndView mav = testInstance.handle(request, response, command, bindingResult);
@@ -140,9 +143,11 @@ public class AddMembersControllerTest extends BaseWCTTest<AddMembersController>{
 	public final void testHandleAddMembers2() {
 		try
 		{
+			BindingResult bindingResult;
 			testSetAuthorityManager();
 			testSetTargetManager();
 			testSetGroupsController();
+			ReflectionTestUtils.setField(testInstance, "addMembersValidator", new AddMembersValidator());
 
 			this.addCurrentUserPrivilege(Privilege.ADD_TARGET_TO_GROUP);
 
@@ -150,13 +155,13 @@ public class AddMembersControllerTest extends BaseWCTTest<AddMembersController>{
 			HttpServletResponse response = new MockHttpServletResponse();
 			AddMembersCommand command = new AddMembersCommand();
 
-            BindingResult bindingResult = new BindException(command, "AddMembersCommand");
-
 			bindEditorContext(request, 15001L);
 
 			command.setActionCmd(AddMembersCommand.ACTION_ADD_MEMBERS);
 			long[]  oids = {4000L};
 			command.setMemberOids(oids);
+
+			bindingResult = new BindException(command, "AddMembersCommand");
 
 			assertTrue(testInstance.getEditorContext(request).getTargetGroup().getNewChildren().size() == 0);
 			ModelAndView mav = testInstance.handle(request, response, command, bindingResult);
@@ -175,9 +180,11 @@ public class AddMembersControllerTest extends BaseWCTTest<AddMembersController>{
 	public final void testHandleAddMembers2NoPriv() {
 		try
 		{
+			BindingResult bindingResult;
 			testSetAuthorityManager();
 			testSetTargetManager();
 			testSetGroupsController();
+			ReflectionTestUtils.setField(testInstance, "addMembersValidator", new AddMembersValidator());
 
 			this.removeAllCurrentUserPrivileges();
 
@@ -185,13 +192,13 @@ public class AddMembersControllerTest extends BaseWCTTest<AddMembersController>{
 			HttpServletResponse response = new MockHttpServletResponse();
 			AddMembersCommand command = new AddMembersCommand();
 
-            BindingResult bindingResult = new BindException(command, "AddMembersCommand");
-
 			bindEditorContext(request, 15001L);
 
 			command.setActionCmd(AddMembersCommand.ACTION_ADD_MEMBERS);
 			long[]  oids = {4000L};
 			command.setMemberOids(oids);
+
+			bindingResult = new BindException(command, "AddMembersCommand");
 
 			assertTrue(testInstance.getEditorContext(request).getTargetGroup().getNewChildren().size() == 0);
 			ModelAndView mav = testInstance.handle(request, response, command, bindingResult);
@@ -210,21 +217,23 @@ public class AddMembersControllerTest extends BaseWCTTest<AddMembersController>{
 	public final void testHandleCancel() {
 		try
 		{
+			BindingResult bindingResult;
 			testSetAuthorityManager();
 			testSetTargetManager();
 			testSetGroupsController();
+			ReflectionTestUtils.setField(testInstance, "addMembersValidator", new AddMembersValidator());
 
 			HttpServletRequest request = new MockHttpServletRequest();
 			HttpServletResponse response = new MockHttpServletResponse();
 			AddMembersCommand command = new AddMembersCommand();
-
-            BindingResult bindingResult = new BindException(command, "AddMembersCommand");
 
 			bindEditorContext(request, 15001L);
 
 			command.setActionCmd(null);
 			long[]  oids = {4000L, 15002L};
 			command.setMemberOids(oids);
+
+			bindingResult = new BindException(command, "AddMembersCommand");
 
 			List<AddMembersController.MemberSelection> selections = (List<AddMembersController.MemberSelection>)request.getSession().getAttribute(AddMembersCommand.SESSION_SELECTIONS);
 			assertNull(selections);
@@ -260,21 +269,23 @@ public class AddMembersControllerTest extends BaseWCTTest<AddMembersController>{
 	public final void testHandleOther() {
 		try
 		{
+			BindingResult bindingResult;
 			testSetAuthorityManager();
 			testSetTargetManager();
 			testSetGroupsController();
+			ReflectionTestUtils.setField(testInstance, "addMembersValidator", new AddMembersValidator());
 
 			HttpServletRequest request = new MockHttpServletRequest();
 			HttpServletResponse response = new MockHttpServletResponse();
 			AddMembersCommand command = new AddMembersCommand();
-
-            BindingResult bindingResult = new BindException(command, "AddMembersCommand");
 
 			bindEditorContext(request, 15001L);
 
 			command.setActionCmd(null);
 			long[]  oids = {4000L, 15002L};
 			command.setMemberOids(oids);
+
+			bindingResult = new BindException(command, "AddMembersCommand");
 
 			List<AddMembersController.MemberSelection> selections = (List<AddMembersController.MemberSelection>)request.getSession().getAttribute(AddMembersCommand.SESSION_SELECTIONS);
 			assertNull(selections);
@@ -297,21 +308,23 @@ public class AddMembersControllerTest extends BaseWCTTest<AddMembersController>{
 	public final void testHandleRemove() {
 		try
 		{
+			BindingResult bindingResult;
 			testSetAuthorityManager();
 			testSetTargetManager();
 			testSetGroupsController();
+			ReflectionTestUtils.setField(testInstance, "addMembersValidator", new AddMembersValidator());
 
 			HttpServletRequest request = new MockHttpServletRequest();
 			HttpServletResponse response = new MockHttpServletResponse();
 			AddMembersCommand command = new AddMembersCommand();
-
-            BindingResult bindingResult = new BindException(command, "AddMembersCommand");
 
 			bindEditorContext(request, 15001L);
 
 			command.setActionCmd(null);
 			long[]  oids = {4000L, 15002L};
 			command.setMemberOids(oids);
+
+			bindingResult = new BindException(command, "AddMembersCommand");
 
 			List<AddMembersController.MemberSelection> selections = (List<AddMembersController.MemberSelection>)request.getSession().getAttribute(AddMembersCommand.SESSION_SELECTIONS);
 			assertNull(selections);

--- a/webcurator-webapp/src/test/java/org/webcurator/ui/groups/controller/GroupAddParentsControllerTest.java
+++ b/webcurator-webapp/src/test/java/org/webcurator/ui/groups/controller/GroupAddParentsControllerTest.java
@@ -11,6 +11,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.servlet.ModelAndView;
@@ -24,6 +25,7 @@ import org.webcurator.ui.groups.GroupsEditorContext;
 import org.webcurator.ui.groups.command.AddParentsCommand;
 import org.webcurator.ui.groups.command.GeneralCommand;
 import org.webcurator.ui.groups.command.MembersCommand;
+import org.webcurator.ui.groups.validator.AddParentsValidator;
 import org.webcurator.ui.groups.validator.GeneralValidator;
 import org.webcurator.ui.util.Tab;
 import org.webcurator.ui.util.TabConfig;
@@ -118,15 +120,15 @@ public class GroupAddParentsControllerTest extends BaseWCTTest<GroupAddParentsCo
 	public final void testHandleAddParents() {
 		try
 		{
+			BindingResult bindingResult;
 			testSetAuthorityManager();
 			testSetTargetManager();
 			testSetGroupsController();
+			ReflectionTestUtils.setField(testInstance, "addParentsValidator", new AddParentsValidator());
 
 			HttpServletRequest request = new MockHttpServletRequest();
 			HttpServletResponse response = new MockHttpServletResponse();
 			AddParentsCommand command = new AddParentsCommand();
-
-            BindingResult bindingResult = new BindException(command, "AddParentsCommand");
 
 			bindEditorContext(request, 15002L);
 			testInstance.getEditorContext(request).getTargetGroup().setName("ParentGroup > ChildGroup");
@@ -134,6 +136,8 @@ public class GroupAddParentsControllerTest extends BaseWCTTest<GroupAddParentsCo
 			command.setActionCmd(AddParentsCommand.ACTION_ADD_PARENTS);
 			long[]  oids = {15000L};
 			command.setParentOids(oids);
+
+			bindingResult = new BindException(command, "AddParentsCommand");
 
 			ModelAndView mav = testInstance.handle(request, response, command, bindingResult);
 			assertNotNull(mav);
@@ -151,15 +155,15 @@ public class GroupAddParentsControllerTest extends BaseWCTTest<GroupAddParentsCo
 	public final void testHandleCancel() {
 		try
 		{
+			BindingResult bindingResult;
 			testSetAuthorityManager();
 			testSetTargetManager();
 			testSetGroupsController();
+			ReflectionTestUtils.setField(testInstance, "addParentsValidator", new AddParentsValidator());
 
 			HttpServletRequest request = new MockHttpServletRequest();
 			HttpServletResponse response = new MockHttpServletResponse();
 			AddParentsCommand command = new AddParentsCommand();
-
-            BindingResult bindingResult = new BindException(command, "AddParentsCommand");
 
 			bindEditorContext(request, 15002L);
 			testInstance.getEditorContext(request).getTargetGroup().setName("ParentGroup > ChildGroup");
@@ -167,6 +171,8 @@ public class GroupAddParentsControllerTest extends BaseWCTTest<GroupAddParentsCo
 			command.setActionCmd(AddParentsCommand.ACTION_CANCEL);
 			long[]  oids = {15000L};
 			command.setParentOids(oids);
+
+			bindingResult = new BindException(command, "AddParentsCommand");
 
 			ModelAndView mav = testInstance.handle(request, response, command, bindingResult);
 			assertNotNull(mav);
@@ -184,19 +190,21 @@ public class GroupAddParentsControllerTest extends BaseWCTTest<GroupAddParentsCo
 	public final void testHandleOther() {
 		try
 		{
+			BindingResult bindingResult;
 			testSetAuthorityManager();
 			testSetTargetManager();
 			testSetGroupsController();
+			ReflectionTestUtils.setField(testInstance, "addParentsValidator", new AddParentsValidator());
 
 			HttpServletRequest request = new MockHttpServletRequest();
 			HttpServletResponse response = new MockHttpServletResponse();
 			AddParentsCommand command = new AddParentsCommand();
 
-			BindingResult bindingResult = new BindException(command, "AddMembersCommand");
-
 			bindEditorContext(request, 15002L);
 
 			command.setActionCmd(null);
+
+			bindingResult = new BindException(command, "AddMembersCommand");
 
 			ModelAndView mav = testInstance.handle(request, response, command, bindingResult);
 			assertNotNull(mav);

--- a/webcurator-webapp/src/test/java/org/webcurator/ui/site/controller/SiteAgencyControllerTest.java
+++ b/webcurator-webapp/src/test/java/org/webcurator/ui/site/controller/SiteAgencyControllerTest.java
@@ -8,6 +8,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.junit.Test;
 import org.springframework.mock.web.*;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.servlet.ModelAndView;
@@ -16,6 +17,7 @@ import org.webcurator.test.BaseWCTTest;
 import org.webcurator.common.ui.Constants;
 import org.webcurator.ui.site.SiteEditorContext;
 import org.webcurator.ui.site.command.*;
+import org.webcurator.ui.site.validator.SiteAgencyValidator;
 import org.webcurator.ui.util.Tab;
 import org.webcurator.ui.util.TabConfig;
 import org.webcurator.core.sites.*;
@@ -35,6 +37,7 @@ public class SiteAgencyControllerTest extends BaseWCTTest<SiteAgencyController>{
 		{
 			MockHttpServletRequest aReq = new MockHttpServletRequest();
 			SiteManager siteManager = new MockSiteManagerImpl(testFile);
+			ReflectionTestUtils.setField(testInstance, "siteAgencyValidator", new SiteAgencyValidator());
 
 			Site site = siteManager.getSite(9000L, true);
 			SiteEditorContext ctx = new SiteEditorContext(site);
@@ -78,6 +81,7 @@ public class SiteAgencyControllerTest extends BaseWCTTest<SiteAgencyController>{
 		{
 			MockHttpServletRequest aReq = new MockHttpServletRequest();
 			SiteManager siteManager = new MockSiteManagerImpl(testFile);
+			ReflectionTestUtils.setField(testInstance, "siteAgencyValidator", new SiteAgencyValidator());
 
 			Site site = siteManager.getSite(9000L, true);
 			SiteEditorContext ctx = new SiteEditorContext(site);

--- a/webcurator-webapp/src/test/java/org/webcurator/ui/site/controller/SitePermissionControllerTest.java
+++ b/webcurator-webapp/src/test/java/org/webcurator/ui/site/controller/SitePermissionControllerTest.java
@@ -11,6 +11,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.junit.Test;
 import org.springframework.mock.web.*;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.servlet.ModelAndView;
@@ -20,6 +21,7 @@ import org.webcurator.ui.site.command.*;
 import org.webcurator.core.sites.*;
 import org.webcurator.core.util.AuthUtil;
 import org.webcurator.domain.model.core.*;
+import org.webcurator.ui.site.validator.SitePermissionValidator;
 
 public class SitePermissionControllerTest extends BaseWCTTest<SitePermissionController>{
 
@@ -82,6 +84,7 @@ public class SitePermissionControllerTest extends BaseWCTTest<SitePermissionCont
 		{
 			HttpServletRequest aReq = new MockHttpServletRequest();
 			SiteManager siteManager = new MockSiteManagerImpl(testFile);
+			ReflectionTestUtils.setField(testInstance, "sitePermissionValidator", new SitePermissionValidator());
 
 			Site site = siteManager.getSite(9000L, true);
 			SiteEditorContext ctx = new SiteEditorContext(site);

--- a/webcurator-webapp/src/test/java/org/webcurator/ui/target/controller/AddParentsControllerTest.java
+++ b/webcurator-webapp/src/test/java/org/webcurator/ui/target/controller/AddParentsControllerTest.java
@@ -6,6 +6,7 @@ import java.util.*;
 
 import javax.servlet.http.*;
 
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.servlet.*;
 import org.springframework.mock.web.*;
@@ -98,15 +99,15 @@ public class AddParentsControllerTest extends BaseWCTTest<AddParentsController>{
 	public final void testHandleAddParents1() {
 		try
 		{
+			BindingResult bindingResult;
 			testSetAuthorityManager();
 			testSetTargetManager();
 			testSetTargetController();
+			ReflectionTestUtils.setField(testInstance, "addParentsValidator", new AddParentsValidator());
 
 			HttpServletRequest request = new MockHttpServletRequest();
 			HttpServletResponse response = new MockHttpServletResponse();
 			AddParentsCommand command = new AddParentsCommand();
-
-            BindingResult bindingResult = new BindException(command, "AddParentsCommand");
 
 			bindEditorContext(request);
 
@@ -114,6 +115,8 @@ public class AddParentsControllerTest extends BaseWCTTest<AddParentsController>{
 			//Already a member of this group
 			long[]  oids = {15000L};
 			command.setParentOids(oids);
+
+			bindingResult = new BindException(command, "AddParentsCommand");
 
 			assertTrue(testInstance.getEditorContext(request).getParents().size() == 1);
 			assertTrue(testInstance.getEditorContext(request).getTarget().getParents().size() == 1);
@@ -135,21 +138,23 @@ public class AddParentsControllerTest extends BaseWCTTest<AddParentsController>{
 	public final void testHandleAddParents2() {
 		try
 		{
+			BindingResult bindingResult;
 			testSetAuthorityManager();
 			testSetTargetManager();
 			testSetTargetController();
+			ReflectionTestUtils.setField(testInstance, "addParentsValidator", new AddParentsValidator());
 
 			HttpServletRequest request = new MockHttpServletRequest();
 			HttpServletResponse response = new MockHttpServletResponse();
 			AddParentsCommand command = new AddParentsCommand();
-
-            BindingResult bindingResult = new BindException(command, "AddParentsCommand");
 
 			bindEditorContext(request);
 
 			command.setActionCmd(AddParentsCommand.ACTION_ADD_PARENTS);
 			long[]  oids = {15001L};
 			command.setParentOids(oids);
+
+			bindingResult = new BindException(command, "AddParentsCommand");
 
 			assertTrue(testInstance.getEditorContext(request).getParents().size() == 1);
 			assertTrue(testInstance.getEditorContext(request).getTarget().getParents().size() == 1);
@@ -169,21 +174,23 @@ public class AddParentsControllerTest extends BaseWCTTest<AddParentsController>{
 	public final void testHandleCancel() {
 		try
 		{
+			BindingResult bindingResult;
 			testSetAuthorityManager();
 			testSetTargetManager();
 			testSetTargetController();
+			ReflectionTestUtils.setField(testInstance, "addParentsValidator", new AddParentsValidator());
 
 			HttpServletRequest request = new MockHttpServletRequest();
 			HttpServletResponse response = new MockHttpServletResponse();
 			AddParentsCommand command = new AddParentsCommand();
-
-            BindingResult bindingResult = new BindException(command, "AddParentsCommand");
 
 			bindEditorContext(request);
 
 			command.setActionCmd(null);
 			long[]  oids = {15001L, 15002L};
 			command.setParentOids(oids);
+
+			bindingResult = new BindException(command, "AddParentsCommand");
 
 			assertTrue(testInstance.getEditorContext(request).getParents().size() == 1);
 			assertTrue(testInstance.getEditorContext(request).getTarget().getParents().size() == 1);
@@ -221,21 +228,23 @@ public class AddParentsControllerTest extends BaseWCTTest<AddParentsController>{
 	public final void testHandleOther() {
 		try
 		{
+			BindingResult bindingResult;
 			testSetAuthorityManager();
 			testSetTargetManager();
 			testSetTargetController();
+			ReflectionTestUtils.setField(testInstance, "addParentsValidator", new AddParentsValidator());
 
 			HttpServletRequest request = new MockHttpServletRequest();
 			HttpServletResponse response = new MockHttpServletResponse();
 			AddParentsCommand command = new AddParentsCommand();
-
-            BindingResult bindingResult = new BindException(command, "AddParentsCommand");
 
 			bindEditorContext(request);
 
 			command.setActionCmd(null);
 			long[]  oids = {15001L, 15002L};
 			command.setParentOids(oids);
+
+			bindingResult = new BindException(command, "AddParentsCommand");
 
 			assertTrue(testInstance.getEditorContext(request).getParents().size() == 1);
 			assertTrue(testInstance.getEditorContext(request).getTarget().getParents().size() == 1);
@@ -260,21 +269,23 @@ public class AddParentsControllerTest extends BaseWCTTest<AddParentsController>{
 	public final void testHandleRemove() {
 		try
 		{
+			BindingResult bindingResult;
 			testSetAuthorityManager();
 			testSetTargetManager();
 			testSetTargetController();
+			ReflectionTestUtils.setField(testInstance, "addParentsValidator", new AddParentsValidator());
 
 			HttpServletRequest request = new MockHttpServletRequest();
 			HttpServletResponse response = new MockHttpServletResponse();
 			AddParentsCommand command = new AddParentsCommand();
-
-            BindingResult bindingResult = new BindException(command, "AddParentsCommand");
 
 			bindEditorContext(request);
 
 			command.setActionCmd(null);
 			long[]  oids = {15001L, 15002L};
 			command.setParentOids(oids);
+
+			bindingResult = new BindException(command, "AddParentsCommand");
 
 			assertTrue(testInstance.getEditorContext(request).getParents().size() == 1);
 			assertTrue(testInstance.getEditorContext(request).getTarget().getParents().size() == 1);

--- a/webcurator-webapp/src/test/java/org/webcurator/ui/target/controller/HarvestNowControllerTest.java
+++ b/webcurator-webapp/src/test/java/org/webcurator/ui/target/controller/HarvestNowControllerTest.java
@@ -12,14 +12,15 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import org.springframework.context.MockMessageSource;
 import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.servlet.ModelAndView;
 import org.webcurator.core.archive.MockSipBuilder;
 import org.webcurator.core.harvester.agent.MockHarvestAgentFactory;
-import org.webcurator.core.harvester.coordinator.HarvestAgentManagerImpl;
 import org.webcurator.core.harvester.coordinator.HarvestBandwidthManager;
 import org.webcurator.core.harvester.coordinator.HarvestCoordinatorImpl;
+import org.webcurator.core.harvester.coordinator.MockHarvestAgentManager;
 import org.webcurator.core.notification.MockInTrayManager;
 import org.webcurator.core.scheduler.MockTargetInstanceManager;
 import org.webcurator.core.targets.MockTargetManager;
@@ -31,6 +32,7 @@ import org.webcurator.domain.model.core.harvester.agent.HarvesterStatusDTO;
 import org.webcurator.test.BaseWCTTest;
 import org.webcurator.ui.target.command.TargetInstanceCommand;
 import org.webcurator.common.util.DateUtils;
+import org.webcurator.ui.target.validator.MockHarvestNowValidator;
 
 public class HarvestNowControllerTest extends BaseWCTTest<HarvestNowController> {
 
@@ -62,7 +64,7 @@ public class HarvestNowControllerTest extends BaseWCTTest<HarvestNowController> 
 		hc.setTargetManager(new MockTargetManager(testFile));
 		hc.setInTrayManager(new MockInTrayManager(testFile));
 		hc.setSipBuilder(new MockSipBuilder(testFile));
-		HarvestAgentManagerImpl harvestAgentManager = new HarvestAgentManagerImpl();
+		MockHarvestAgentManager harvestAgentManager = new MockHarvestAgentManager();
 		harvestAgentManager.setHarvestAgentFactory(new MockHarvestAgentFactory());
 		harvestAgentManager.setTargetInstanceManager(tim);
 		harvestAgentManager.setTargetInstanceDao(tidao);
@@ -95,6 +97,9 @@ public class HarvestNowControllerTest extends BaseWCTTest<HarvestNowController> 
 		TargetInstance ti = tidao.load(5001L);
 		ti.setState(TargetInstance.STATE_SCHEDULED);
 
+		BindingResult bindingResult;
+
+
 		HashMap<String, HarvesterStatusDTO> aHarvesterStatus = new HashMap<String, HarvesterStatusDTO>();
 
 		aHarvesterStatus.put("Target-5002", getStatusDTO("Running"));
@@ -110,7 +115,10 @@ public class HarvestNowControllerTest extends BaseWCTTest<HarvestNowController> 
 		aCmd.setCmd(TargetInstanceCommand.ACTION_HARVEST);
 		aCmd.setAgent("Test Agent");
 		aCmd.setTargetInstanceId(5001L);
-        BindingResult bindingResult = new BindException(aCmd, TargetInstanceCommand.ACTION_HARVEST);
+
+        bindingResult = new BindException(aCmd, TargetInstanceCommand.ACTION_HARVEST);
+		ReflectionTestUtils.setField(testInstance, "harvestNowValidator", new MockHarvestNowValidator());
+		ReflectionTestUtils.setField(testInstance, "harvestCoordinator", hc);
 
 		ModelAndView mav = testInstance.processFormSubmission(aCmd, bindingResult, aReq);
 		assertTrue(mav != null);
@@ -141,6 +149,9 @@ public class HarvestNowControllerTest extends BaseWCTTest<HarvestNowController> 
 		aCmd.setAgent("Test Agent");
 		aCmd.setTargetInstanceId(5001L);
         BindingResult bindingResult = new BindException(aCmd, TargetInstanceCommand.ACTION_HARVEST);
+
+        ReflectionTestUtils.setField(testInstance, "harvestNowValidator", new MockHarvestNowValidator());
+        ReflectionTestUtils.setField(testInstance, "harvestCoordinator", hc);
 
 		try
 		{
@@ -179,6 +190,9 @@ public class HarvestNowControllerTest extends BaseWCTTest<HarvestNowController> 
 		aCmd.setAgent("Test Agent");
 		aCmd.setTargetInstanceId(5001L);
         BindingResult bindingResult = new BindException(aCmd, TargetInstanceCommand.ACTION_HARVEST);
+
+        ReflectionTestUtils.setField(testInstance, "harvestNowValidator", new MockHarvestNowValidator());
+        ReflectionTestUtils.setField(testInstance, "harvestCoordinator", hc);
 
 		ModelAndView mav = testInstance.processFormSubmission(aCmd, bindingResult, aReq);
 		assertTrue(mav != null);

--- a/webcurator-webapp/src/test/java/org/webcurator/ui/target/controller/LogReaderControllerTest.java
+++ b/webcurator-webapp/src/test/java/org/webcurator/ui/target/controller/LogReaderControllerTest.java
@@ -3,6 +3,7 @@ package org.webcurator.ui.target.controller;
 import static org.junit.Assert.*;
 
 import org.junit.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.servlet.ModelAndView;
@@ -12,6 +13,7 @@ import org.webcurator.ui.target.command.LogReaderCommand;
 import org.webcurator.core.harvester.coordinator.*;
 import org.webcurator.core.scheduler.*;
 import org.webcurator.domain.model.core.*;
+import org.webcurator.ui.target.validator.LogReaderValidator;
 
 import java.util.List;
 
@@ -52,8 +54,10 @@ public class LogReaderControllerTest extends BaseWCTTest<LogReaderController>{
 	public final void testHandleHead() {
 		try
 		{
+			BindingResult bindingResult;
 			testInstance.setTargetInstanceManager(tim);
 			testInstance.setHarvestCoordinator(hc);
+			ReflectionTestUtils.setField(testInstance, "logReaderValidator", new LogReaderValidator());
 
 			LogReaderCommand aCmd = new LogReaderCommand();
 			TargetInstance ti = tim.getTargetInstance(5000L);
@@ -63,7 +67,7 @@ public class LogReaderControllerTest extends BaseWCTTest<LogReaderController>{
 			aCmd.setFilterType(LogReaderCommand.VALUE_HEAD);
 			aCmd.setShowLineNumbers(true);
 
-			BindingResult bindingResult = new BindException(aCmd, "LogReaderCommand");
+			bindingResult = new BindException(aCmd, "LogReaderCommand");
 
 			ModelAndView mav = testInstance.handle(aCmd, bindingResult);
 			assertTrue(mav != null);
@@ -85,8 +89,10 @@ public class LogReaderControllerTest extends BaseWCTTest<LogReaderController>{
 	public final void testHandleTail() {
 		try
 		{
+			BindingResult bindingResult;
 			testInstance.setTargetInstanceManager(tim);
 			testInstance.setHarvestCoordinator(hc);
+			ReflectionTestUtils.setField(testInstance, "logReaderValidator", new LogReaderValidator());
 
 			LogReaderCommand aCmd = new LogReaderCommand();
 			TargetInstance ti = tim.getTargetInstance(5000L);
@@ -96,7 +102,7 @@ public class LogReaderControllerTest extends BaseWCTTest<LogReaderController>{
 			aCmd.setFilterType(LogReaderCommand.VALUE_TAIL);
 			aCmd.setShowLineNumbers(true);
 
-            BindingResult bindingResult = new BindException(aCmd, "LogReaderCommand");
+            bindingResult = new BindException(aCmd, "LogReaderCommand");
 
 			ModelAndView mav = testInstance.handle(aCmd, bindingResult);
 			assertTrue(mav != null);
@@ -118,8 +124,10 @@ public class LogReaderControllerTest extends BaseWCTTest<LogReaderController>{
 	public final void testHandleFromLine() {
 		try
 		{
+			BindingResult bindingResult;
 			testInstance.setTargetInstanceManager(tim);
 			testInstance.setHarvestCoordinator(hc);
+			ReflectionTestUtils.setField(testInstance, "logReaderValidator", new LogReaderValidator());
 
 			LogReaderCommand aCmd = new LogReaderCommand();
 			TargetInstance ti = tim.getTargetInstance(5000L);
@@ -130,7 +138,7 @@ public class LogReaderControllerTest extends BaseWCTTest<LogReaderController>{
 			aCmd.setFilter("5000");
 			aCmd.setShowLineNumbers(true);
 
-            BindingResult bindingResult = new BindException(aCmd, "LogReaderCommand");
+            bindingResult = new BindException(aCmd, "LogReaderCommand");
 
 			ModelAndView mav = testInstance.handle(aCmd, bindingResult);
 			assertTrue(mav != null);
@@ -151,8 +159,10 @@ public class LogReaderControllerTest extends BaseWCTTest<LogReaderController>{
 	public final void testHandleTimestamp1() {
 		try
 		{
+			BindingResult bindingResult;
 			testInstance.setTargetInstanceManager(tim);
 			testInstance.setHarvestCoordinator(hc);
+			ReflectionTestUtils.setField(testInstance, "logReaderValidator", new LogReaderValidator());
 
 			LogReaderCommand aCmd = new LogReaderCommand();
 			TargetInstance ti = tim.getTargetInstance(5000L);
@@ -163,7 +173,7 @@ public class LogReaderControllerTest extends BaseWCTTest<LogReaderController>{
 			aCmd.setFilter("2008-06-18T06:25:29");
 			aCmd.setShowLineNumbers(true);
 
-            BindingResult bindingResult = new BindException(aCmd, "LogReaderCommand");
+            bindingResult = new BindException(aCmd, "LogReaderCommand");
 
 			ModelAndView mav = testInstance.handle(aCmd, bindingResult);
 			assertTrue(mav != null);
@@ -185,8 +195,10 @@ public class LogReaderControllerTest extends BaseWCTTest<LogReaderController>{
 	public final void testHandleTimestamp2() {
 		try
 		{
+			BindingResult bindingResult;
 			testInstance.setTargetInstanceManager(tim);
 			testInstance.setHarvestCoordinator(hc);
+			ReflectionTestUtils.setField(testInstance, "logReaderValidator", new LogReaderValidator());
 
 			LogReaderCommand aCmd = new LogReaderCommand();
 			TargetInstance ti = tim.getTargetInstance(5000L);
@@ -197,7 +209,7 @@ public class LogReaderControllerTest extends BaseWCTTest<LogReaderController>{
 			aCmd.setFilter("2008-06-18");
 			aCmd.setShowLineNumbers(true);
 
-            BindingResult bindingResult = new BindException(aCmd, "LogReaderCommand");
+            bindingResult = new BindException(aCmd, "LogReaderCommand");
 
 			ModelAndView mav = testInstance.handle(aCmd, bindingResult);
 			assertTrue(mav != null);
@@ -218,8 +230,10 @@ public class LogReaderControllerTest extends BaseWCTTest<LogReaderController>{
 	public final void testHandleTimestamp3() {
 		try
 		{
+			BindingResult bindingResult;
 			testInstance.setTargetInstanceManager(tim);
 			testInstance.setHarvestCoordinator(hc);
+			ReflectionTestUtils.setField(testInstance, "logReaderValidator", new LogReaderValidator());
 
 			LogReaderCommand aCmd = new LogReaderCommand();
 			TargetInstance ti = tim.getTargetInstance(5000L);
@@ -230,7 +244,7 @@ public class LogReaderControllerTest extends BaseWCTTest<LogReaderController>{
 			aCmd.setFilter("18/06/2008 06:25:29");
 			aCmd.setShowLineNumbers(true);
 
-            BindingResult bindingResult = new BindException(aCmd, "LogReaderCommand");
+            bindingResult = new BindException(aCmd, "LogReaderCommand");
 
 			ModelAndView mav = testInstance.handle(aCmd, bindingResult);
 			assertTrue(mav != null);
@@ -251,8 +265,10 @@ public class LogReaderControllerTest extends BaseWCTTest<LogReaderController>{
 	public final void testHandleTimestamp4() {
 		try
 		{
+			BindingResult bindingResult;
 			testInstance.setTargetInstanceManager(tim);
 			testInstance.setHarvestCoordinator(hc);
+			ReflectionTestUtils.setField(testInstance, "logReaderValidator", new LogReaderValidator());
 
 			LogReaderCommand aCmd = new LogReaderCommand();
 			TargetInstance ti = tim.getTargetInstance(5000L);
@@ -263,7 +279,7 @@ public class LogReaderControllerTest extends BaseWCTTest<LogReaderController>{
 			aCmd.setFilter("18/06/2008");
 			aCmd.setShowLineNumbers(true);
 
-            BindingResult bindingResult = new BindException(aCmd, "LogReaderCommand");
+            bindingResult = new BindException(aCmd, "LogReaderCommand");
 
 			ModelAndView mav = testInstance.handle(aCmd, bindingResult);
 			assertTrue(mav != null);
@@ -284,8 +300,10 @@ public class LogReaderControllerTest extends BaseWCTTest<LogReaderController>{
 	public final void testHandleTimestamp5() {
 		try
 		{
+			BindingResult bindingResult;
 			testInstance.setTargetInstanceManager(tim);
 			testInstance.setHarvestCoordinator(hc);
+			ReflectionTestUtils.setField(testInstance, "logReaderValidator", new LogReaderValidator());
 
 			LogReaderCommand aCmd = new LogReaderCommand();
 			TargetInstance ti = tim.getTargetInstance(5000L);
@@ -296,7 +314,7 @@ public class LogReaderControllerTest extends BaseWCTTest<LogReaderController>{
 			aCmd.setFilter("20080618062529");
 			aCmd.setShowLineNumbers(true);
 
-            BindingResult bindingResult = new BindException(aCmd, "LogReaderCommand");
+            bindingResult = new BindException(aCmd, "LogReaderCommand");
 
 			ModelAndView mav = testInstance.handle(aCmd, bindingResult);
 			assertTrue(mav != null);
@@ -317,8 +335,10 @@ public class LogReaderControllerTest extends BaseWCTTest<LogReaderController>{
 	public final void testHandleTimestamp6() {
 		try
 		{
+			BindingResult bindingResult;
 			testInstance.setTargetInstanceManager(tim);
 			testInstance.setHarvestCoordinator(hc);
+			ReflectionTestUtils.setField(testInstance, "logReaderValidator", new LogReaderValidator());
 
 			LogReaderCommand aCmd = new LogReaderCommand();
 			TargetInstance ti = tim.getTargetInstance(5000L);
@@ -328,7 +348,7 @@ public class LogReaderControllerTest extends BaseWCTTest<LogReaderController>{
 			aCmd.setFilterType(LogReaderCommand.VALUE_TIMESTAMP);
 			aCmd.setFilter("bad format");
 
-            BindingResult bindingResult = new BindException(aCmd, "LogReaderCommand");
+            bindingResult = new BindException(aCmd, "LogReaderCommand");
 
 			ModelAndView mav = testInstance.handle(aCmd, bindingResult);
 			assertTrue(mav != null);
@@ -350,8 +370,10 @@ public class LogReaderControllerTest extends BaseWCTTest<LogReaderController>{
 	public final void testHandleRegexMatch() {
 		try
 		{
+			BindingResult bindingResult;
 			testInstance.setTargetInstanceManager(tim);
 			testInstance.setHarvestCoordinator(hc);
+			ReflectionTestUtils.setField(testInstance, "logReaderValidator", new LogReaderValidator());
 
 			LogReaderCommand aCmd = new LogReaderCommand();
 			TargetInstance ti = tim.getTargetInstance(5000L);
@@ -362,7 +384,7 @@ public class LogReaderControllerTest extends BaseWCTTest<LogReaderController>{
 			aCmd.setFilterType(LogReaderCommand.VALUE_REGEX_MATCH);
 			aCmd.setShowLineNumbers(false);
 
-            BindingResult bindingResult = new BindException(aCmd, "LogReaderCommand");
+            bindingResult = new BindException(aCmd, "LogReaderCommand");
 
 			ModelAndView mav = testInstance.handle(aCmd, bindingResult);
 			assertTrue(mav != null);
@@ -383,8 +405,10 @@ public class LogReaderControllerTest extends BaseWCTTest<LogReaderController>{
 	public final void testHandleRegexMatchLineNumbers() {
 		try
 		{
+			BindingResult bindingResult;
 			testInstance.setTargetInstanceManager(tim);
 			testInstance.setHarvestCoordinator(hc);
+			ReflectionTestUtils.setField(testInstance, "logReaderValidator", new LogReaderValidator());
 
 			LogReaderCommand aCmd = new LogReaderCommand();
 			TargetInstance ti = tim.getTargetInstance(5000L);
@@ -395,7 +419,7 @@ public class LogReaderControllerTest extends BaseWCTTest<LogReaderController>{
 			aCmd.setFilterType(LogReaderCommand.VALUE_REGEX_MATCH);
 			aCmd.setShowLineNumbers(true);
 
-            BindingResult bindingResult = new BindException(aCmd, "LogReaderCommand");
+            bindingResult = new BindException(aCmd, "LogReaderCommand");
 
 			ModelAndView mav = testInstance.handle(aCmd, bindingResult);
 			assertTrue(mav != null);
@@ -416,8 +440,10 @@ public class LogReaderControllerTest extends BaseWCTTest<LogReaderController>{
 	public final void testHandleRegexContain() {
 		try
 		{
+			BindingResult bindingResult;
 			testInstance.setTargetInstanceManager(tim);
 			testInstance.setHarvestCoordinator(hc);
+			ReflectionTestUtils.setField(testInstance, "logReaderValidator", new LogReaderValidator());
 
 			LogReaderCommand aCmd = new LogReaderCommand();
 			TargetInstance ti = tim.getTargetInstance(5000L);
@@ -428,7 +454,7 @@ public class LogReaderControllerTest extends BaseWCTTest<LogReaderController>{
 			aCmd.setFilterType(LogReaderCommand.VALUE_REGEX_CONTAIN);
 			aCmd.setShowLineNumbers(true);
 
-            BindingResult bindingResult = new BindException(aCmd, "LogReaderCommand");
+            bindingResult = new BindException(aCmd, "LogReaderCommand");
 
 			ModelAndView mav = testInstance.handle(aCmd, bindingResult);
 			assertTrue(mav != null);
@@ -449,8 +475,10 @@ public class LogReaderControllerTest extends BaseWCTTest<LogReaderController>{
 	public final void testHandleRegexIndent() {
 		try
 		{
+			BindingResult bindingResult;
 			testInstance.setTargetInstanceManager(tim);
 			testInstance.setHarvestCoordinator(hc);
+			ReflectionTestUtils.setField(testInstance, "logReaderValidator", new LogReaderValidator());
 
 			LogReaderCommand aCmd = new LogReaderCommand();
 			TargetInstance ti = tim.getTargetInstance(5000L);
@@ -461,7 +489,7 @@ public class LogReaderControllerTest extends BaseWCTTest<LogReaderController>{
 			aCmd.setFilterType(LogReaderCommand.VALUE_REGEX_INDENT);
 			aCmd.setShowLineNumbers(true);
 
-            BindingResult bindingResult = new BindException(aCmd, "LogReaderCommand");
+            bindingResult = new BindException(aCmd, "LogReaderCommand");
 
 			ModelAndView mav = testInstance.handle(aCmd, bindingResult);
 			assertTrue(mav != null);

--- a/webcurator-webapp/src/test/java/org/webcurator/ui/target/controller/QueueControllerTest.java
+++ b/webcurator-webapp/src/test/java/org/webcurator/ui/target/controller/QueueControllerTest.java
@@ -52,15 +52,7 @@ import org.webcurator.core.util.AuthUtil;
 import org.webcurator.domain.FlagDAO;
 import org.webcurator.domain.MockTargetInstanceDAO;
 import org.webcurator.domain.TargetInstanceCriteria;
-import org.webcurator.domain.model.core.Flag;
-import org.webcurator.domain.model.core.HarvestResource;
-import org.webcurator.domain.model.core.HarvestResourceDTO;
-import org.webcurator.domain.model.core.HarvestResult;
-import org.webcurator.domain.model.core.Indicator;
-import org.webcurator.domain.model.core.RejReason;
-import org.webcurator.domain.model.core.Seed;
-import org.webcurator.domain.model.core.Target;
-import org.webcurator.domain.model.core.TargetInstance;
+import org.webcurator.domain.model.core.*;
 import org.webcurator.test.BaseWCTTest;
 import org.webcurator.ui.admin.command.FlagCommand;
 import org.webcurator.common.ui.Constants;
@@ -574,7 +566,7 @@ public class QueueControllerTest extends BaseWCTTest<QueueController> {
 		seedSet.add(seed1);
 		seedSet.add(seed2);
 		when(target.getSeeds()).thenReturn(seedSet);
-		HarvestResult result1 = new HarvestResult();
+		ArcHarvestResult result1 = new ArcHarvestResult();
 		result1.setState(HarvestResult.STATE_ENDORSED);
 		result1.setTargetInstance(targetInstance);
 		result1.setOid(5235L);
@@ -618,7 +610,7 @@ public class QueueControllerTest extends BaseWCTTest<QueueController> {
 		seedSet.add(seed1);
 		seedSet.add(seed2);
 		when(target.getSeeds()).thenReturn(seedSet);
-		HarvestResult result1 = new HarvestResult();
+		ArcHarvestResult result1 = new ArcHarvestResult();
 		result1.setState(HarvestResult.STATE_ENDORSED);
 		result1.setTargetInstance(targetInstance);
 		result1.setOid(5235L);
@@ -705,11 +697,11 @@ public class QueueControllerTest extends BaseWCTTest<QueueController> {
 		when(mockTiManager.getTargetInstance(5000L)).thenReturn(mockTI1);
 		when(mockTiManager.getTargetInstance(234L)).thenReturn(mockTI2);
 
-		HarvestResult result1 = new HarvestResult();
+		HarvestResult result1 = new ArcHarvestResult();
 		result1.setState(HarvestResult.STATE_UNASSESSED);
 		result1.setOid(1L);
 		when(mockTiManager.getHarvestResults(5000L)).thenReturn(Arrays.asList(result1));
-		HarvestResult result2 = new HarvestResult();
+		HarvestResult result2 = new ArcHarvestResult();
 		result2.setState(HarvestResult.STATE_UNASSESSED);
 		result2.setOid(2L);
 		when(mockTiManager.getHarvestResults(234L)).thenReturn(Arrays.asList(result2));
@@ -731,10 +723,10 @@ public class QueueControllerTest extends BaseWCTTest<QueueController> {
 		TargetInstanceManager mockTiManager = mock(TargetInstanceManager.class);
 		when(mockTiManager.getTargetInstance(5000L)).thenReturn(mockTI1);
 
-		HarvestResult result1 = mock(HarvestResult.class);
+		ArcHarvestResult result1 = mock(ArcHarvestResult.class);
 		when(result1.getState()).thenReturn(HarvestResult.STATE_ABORTED);
 		when(result1.getOid()).thenReturn(1L);
-		HarvestResult result2 = mock(HarvestResult.class);
+		ArcHarvestResult result2 = mock(ArcHarvestResult.class);
 		when(result2.getState()).thenReturn(HarvestResult.STATE_UNASSESSED);
 		when(result2.getOid()).thenReturn(2L);
 		when(mockTI1.getHarvestResults()).thenReturn(Arrays.asList(result1, result2));
@@ -765,12 +757,12 @@ public class QueueControllerTest extends BaseWCTTest<QueueController> {
 		when(mockTiManager.getTargetInstance(5000L)).thenReturn(mockTI1);
 		when(mockTiManager.getTargetInstance(234L)).thenReturn(mockTI2);
 
-		HarvestResult result1 = mock(HarvestResult.class);
+		ArcHarvestResult result1 = mock(ArcHarvestResult.class);
 		when(result1.getState()).thenReturn(HarvestResult.STATE_ABORTED);
 		when(result1.getOid()).thenReturn(1L);
 		when(mockTI1.getHarvestResults()).thenReturn(Arrays.asList(result1));
 		when(mockTiManager.getHarvestResults(5000L)).thenReturn(Arrays.asList(result1));
-		HarvestResult result2 = mock(HarvestResult.class);
+		ArcHarvestResult result2 = mock(ArcHarvestResult.class);
 		when(result2.getState()).thenReturn(HarvestResult.STATE_REJECTED);
 		when(result2.getOid()).thenReturn(2L);
 		when(mockTI2.getHarvestResults()).thenReturn(Arrays.asList(result2));
@@ -809,12 +801,12 @@ public class QueueControllerTest extends BaseWCTTest<QueueController> {
 		when(mockTiManager.getTargetInstance(5000L)).thenReturn(mockTI1);
 		when(mockTiManager.getTargetInstance(234L)).thenReturn(mockTI2);
 
-		HarvestResult result1 = mock(HarvestResult.class);
+		ArcHarvestResult result1 = mock(ArcHarvestResult.class);
 		when(result1.getState()).thenReturn(HarvestResult.STATE_ABORTED);
 		when(result1.getOid()).thenReturn(1L);
 		when(mockTI1.getHarvestResults()).thenReturn(Arrays.asList(result1));
 		when(mockTiManager.getHarvestResults(5000L)).thenReturn(Arrays.asList(result1));
-		HarvestResult result2 = mock(HarvestResult.class);
+		ArcHarvestResult result2 = mock(ArcHarvestResult.class);
 		when(result2.getState()).thenReturn(HarvestResult.STATE_REJECTED);
 		when(result2.getOid()).thenReturn(2L);
 		when(mockTI2.getHarvestResults()).thenReturn(Arrays.asList(result2));
@@ -877,7 +869,7 @@ public class QueueControllerTest extends BaseWCTTest<QueueController> {
 	}
 
 	private TargetInstanceManager setTargetInstanceManager(Long tOid, Long hrOid, int state) {
-		HarvestResult result1 = new HarvestResult();
+		HarvestResult result1 = new ArcHarvestResult();
 		result1.setState(state);
 		result1.setOid(hrOid);
 		TargetInstanceManager mockTiManager = mock(TargetInstanceManager.class);

--- a/webcurator-webapp/src/test/java/org/webcurator/ui/target/controller/TargetInstanceResultHandlerTest.java
+++ b/webcurator-webapp/src/test/java/org/webcurator/ui/target/controller/TargetInstanceResultHandlerTest.java
@@ -13,8 +13,11 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.junit.Test;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.servlet.ModelAndView;
@@ -23,8 +26,10 @@ import org.webcurator.core.agency.MockAgencyUserManagerImpl;
 import org.webcurator.core.exceptions.DigitalAssetStoreException;
 import org.webcurator.core.harvester.coordinator.HarvestCoordinatorImpl;
 import org.webcurator.core.harvester.coordinator.MockHarvestCoordinator;
+import org.webcurator.core.notification.InTrayManagerImpl;
 import org.webcurator.core.scheduler.MockTargetInstanceManager;
 import org.webcurator.core.scheduler.TargetInstanceManager;
+import org.webcurator.core.store.DigitalAssetStoreClient;
 import org.webcurator.core.store.MockDigitalAssetStore;
 import org.webcurator.domain.model.core.CustomDepositFormCriteriaDTO;
 import org.webcurator.domain.model.core.CustomDepositFormResultDTO;
@@ -103,6 +108,14 @@ public class TargetInstanceResultHandlerTest extends BaseWCTTest<TargetInstanceR
 		testInstance.setHarvestCoordinator(coordinator);
 		testInstance.setDigitalAssetStore(digitalAssetStore);
 		testInstance.setAgencyUserManager(new MockAgencyUserManagerImpl(testFile));
+
+		DigitalAssetStoreClient mockDasClient = new DigitalAssetStoreClient("http","wctstore.natlib.govt.nz", 19090, new RestTemplateBuilder());
+		InTrayManagerImpl mockInTrayManager = new InTrayManagerImpl();
+		mockInTrayManager.setWctBaseUrl("http://${core.host}:${core.port}/");
+		ReflectionTestUtils.setField(testInstance, "digitalAssetStoreClient", mockDasClient);
+		ReflectionTestUtils.setField(testInstance, "inTrayManager", mockInTrayManager);
+
+
 		TargetInstance targetInstance = targetInstanceManager.getTargetInstance(5000L);
 		List<HarvestResult> results = targetInstanceManager.getHarvestResults(targetInstance.getOid());
 		HarvestResult result = results.get(0);
@@ -362,6 +375,12 @@ public class TargetInstanceResultHandlerTest extends BaseWCTTest<TargetInstanceR
 		TargetInstance targetInstance = targetInstanceManager.getTargetInstance(5000L);
 		TabbedModelAndView mav;
 		MockDigitalAssetStore digitalAssetStore;
+
+		DigitalAssetStoreClient mockDasClient = new DigitalAssetStoreClient("http","wctstore.natlib.govt.nz", 19090, new RestTemplateBuilder());
+		InTrayManagerImpl mockInTrayManager = new InTrayManagerImpl();
+		mockInTrayManager.setWctBaseUrl("http://${core.host}:${core.port}/");
+		ReflectionTestUtils.setField(testInstance, "digitalAssetStoreClient", mockDasClient);
+		ReflectionTestUtils.setField(testInstance, "inTrayManager", mockInTrayManager);
 
 		// Harvest is in ENDORSED state and the DAS returns a valid response DTO
 		digitalAssetStore = new MockDigitalAssetStore() {

--- a/webcurator-webapp/src/test/java/org/webcurator/ui/target/validator/MockHarvestNowValidator.java
+++ b/webcurator-webapp/src/test/java/org/webcurator/ui/target/validator/MockHarvestNowValidator.java
@@ -1,0 +1,81 @@
+/*
+ *  Copyright 2006 The National Library of New Zealand
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.webcurator.ui.target.validator;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.Errors;
+import org.springframework.validation.ValidationUtils;
+import org.webcurator.common.ui.CommandConstants;
+import org.webcurator.ui.common.validation.AbstractBaseValidator;
+import org.webcurator.ui.common.validation.ValidatorUtil;
+import org.webcurator.ui.target.command.TargetInstanceCommand;
+
+/**
+ * Validate a request to harvest a target instance now.
+ */
+//@Component
+//@Scope(BeanDefinition.SCOPE_SINGLETON)
+//@Lazy(false)
+public class MockHarvestNowValidator extends HarvestNowValidator {
+
+    /** Logger to use with this class. */
+    private Log log;
+
+    /** default constructor. */
+    public MockHarvestNowValidator() {
+        super();
+        log = LogFactory.getLog(MockHarvestNowValidator.class);
+    }
+
+    /* (non-Javadoc)
+     * @see org.springframework.validation.Validator#supports(java.lang.Class)
+     */
+    public boolean supports(Class aClass) {
+        return aClass.equals(TargetInstanceCommand.class);
+    }
+
+    /* (non-Javadoc)
+     * @see org.springframework.validation.Validator#validate(java.lang.Object, org.springframework.validation.Errors)
+     */
+    public void validate(Object aCommand, Errors aErrors) {
+        TargetInstanceCommand cmd = (TargetInstanceCommand) aCommand;
+        if (log.isDebugEnabled()) {
+            log.debug("Validating harvest now target instance command.");
+        }
+
+        ValidationUtils.rejectIfEmptyOrWhitespace(aErrors, TargetInstanceCommand.PARAM_CMD, "required", getObjectArrayForLabel(TargetInstanceCommand.PARAM_CMD), "Action command is a required field.");
+
+        if (TargetInstanceCommand.ACTION_HARVEST.equals(cmd.getCmd())) {
+            ValidationUtils.rejectIfEmptyOrWhitespace(aErrors, TargetInstanceCommand.PARAM_AGENT, "required", getObjectArrayForLabel(TargetInstanceCommand.PARAM_AGENT), "Harvest agent is a required field.");
+            ValidationUtils.rejectIfEmptyOrWhitespace(aErrors, CommandConstants.TARGET_INSTANCE_COMMAND_PARAM_OID, "required", getObjectArrayForLabel(CommandConstants.TARGET_INSTANCE_COMMAND_PARAM_OID), "Target Instance Id is a required field.");
+//            if (!aErrors.hasErrors()) {
+//                ValidatorUtil.validateMinimumBandwidthAvailable(aErrors, cmd.getTargetInstanceId(), "no.minimum.bandwidth", getObjectArrayForLabel(CommandConstants.TARGET_INSTANCE_COMMAND_PARAM_OID), "Adding this target instance will reduce the bandwidth.");
+//                if (cmd.getBandwidthPercent() != null) {
+//                	ValidatorUtil.validateMaxBandwidthPercentage(aErrors, cmd.getBandwidthPercent().intValue(), "max.bandwidth.exeeded");
+//                }
+//            }
+//
+//            if (!aErrors.hasErrors()) {
+//            	ValidatorUtil.validateTargetApproved(aErrors, cmd.getTargetInstanceId(), "target.not.approved");
+//            }
+        }
+    }
+}

--- a/webcurator-webapp/src/test/java/org/webcurator/ui/tools/controller/HarvestResourceUrlMapperTest.java
+++ b/webcurator-webapp/src/test/java/org/webcurator/ui/tools/controller/HarvestResourceUrlMapperTest.java
@@ -12,6 +12,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import org.webcurator.domain.model.core.ArcHarvestResource;
+import org.webcurator.domain.model.core.ArcHarvestResult;
 import org.webcurator.domain.model.core.HarvestResult;
 import org.webcurator.domain.model.core.TargetInstance;
 import org.webcurator.ui.target.validator.TargetAccessValidatorTest;
@@ -31,7 +32,7 @@ public class HarvestResourceUrlMapperTest extends TestCase {
 		hRsr.setStatusCode(2);
 		hRsr.setArcFileName("BL-123456-20091231235959-00000-localhost.arc.gz");
 
-		HarvestResult hRslt = new HarvestResult();
+		ArcHarvestResult hRslt = new ArcHarvestResult();
 		SimpleDateFormat format = new SimpleDateFormat("d/M/y hh:mm:ss");
 		Date d = format.parse("3/11/2004 10:20:11");
 		hRslt.setCreationDate(d);

--- a/webcurator-webapp/src/test/java/org/webcurator/ui/tools/controller/TreeToolControllerAJAXTest.java
+++ b/webcurator-webapp/src/test/java/org/webcurator/ui/tools/controller/TreeToolControllerAJAXTest.java
@@ -7,6 +7,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.ServletRequestDataBinder;
@@ -23,6 +24,7 @@ import org.webcurator.domain.model.core.HarvestResource;
 import org.webcurator.test.BaseWCTTest;
 import org.webcurator.ui.admin.command.AgencyCommand;
 import org.webcurator.ui.tools.command.TreeToolCommand;
+import org.webcurator.ui.tools.validator.TreeToolValidator;
 
 public class TreeToolControllerAJAXTest extends BaseWCTTest<TreeToolControllerAJAX> {
 
@@ -54,7 +56,11 @@ public class TreeToolControllerAJAXTest extends BaseWCTTest<TreeToolControllerAJ
 		// just set up one request (this will then keep the session)
 		aReq = new MockHttpServletRequest();
 
-		testInstance.setQualityReviewFacade(qrf);
+		ReflectionTestUtils.setField(testInstance, "qualityReviewFacade", qrf);
+        TreeToolControllerAttribute mockTTCA = new TreeToolControllerAttribute();
+        mockTTCA.setAutoQAUrl("");
+        ReflectionTestUtils.setField(testInstance, "treeToolControllerAttribute", mockTTCA);
+        ReflectionTestUtils.setField(testInstance, "treeToolValidator", new TreeToolValidator());
 
 	}
 


### PR DESCRIPTION
A mix of fixes:

- class variables not mocked (mostly validators)
- invalid types used
- nested Application context calls failing
- command objects not added to BindingResult objects

To trigger running of unit tests, use `gradle clean build`