### PR TITLE
Hanging stopping jobs

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,2 @@
 rootProject.name = 'webcurator'
-include 'webcurator-legacy-lib-dependencies', 'webcurator-db', 'webcurator-core', 'webcurator-webapp', 'webcurator-docs', 'webcurator-harvest-agent-h3', 'webcurator-harvest-agent-h1', 'webcurator-submit-to-rosetta', 'webcurator-store'
+include 'webcurator-legacy-lib-dependencies', 'webcurator-core', 'webcurator-webapp', 'webcurator-docs', 'webcurator-harvest-agent-h3', 'webcurator-harvest-agent-h1', 'webcurator-submit-to-rosetta', 'webcurator-store'

--- a/webcurator-core/src/main/java/org/webcurator/core/harvester/agent/HarvestAgentClient.java
+++ b/webcurator-core/src/main/java/org/webcurator/core/harvester/agent/HarvestAgentClient.java
@@ -42,14 +42,14 @@ public class HarvestAgentClient extends AbstractRestClient implements HarvestAge
         URI uri=uriComponentsBuilder.buildAndExpand(pathVariables).toUri();
 
         RestTemplate restTemplate = restTemplateBuilder.build();
-        restTemplate.postForObject(uri, params, Void.class);
+        restTemplate.postForObject(uri, params, String.class);
     }
 
     public void recoverHarvests(List<String> activeJobs) {
         HttpEntity<String> request = this.createHttpRequestEntity(activeJobs);
 
         RestTemplate restTemplate = restTemplateBuilder.build();
-        restTemplate.postForObject(getUrl(HarvestAgentPaths.RECOVER_HARVESTS), request, Void.class);
+        restTemplate.postForObject(getUrl(HarvestAgentPaths.RECOVER_HARVESTS), request, String.class);
     }
 
     /**
@@ -63,7 +63,7 @@ public class HarvestAgentClient extends AbstractRestClient implements HarvestAge
 
         RestTemplate restTemplate = restTemplateBuilder.build();
         restTemplate.postForObject(uriComponentsBuilder.buildAndExpand(pathVariables).toUri(),
-                null, Void.class);
+                null, String.class);
     }
 
     /**
@@ -75,7 +75,7 @@ public class HarvestAgentClient extends AbstractRestClient implements HarvestAge
 
         RestTemplate restTemplate = restTemplateBuilder.build();
         restTemplate.postForObject(uriComponentsBuilder.buildAndExpand(pathVariables).toUri(),
-                null, Void.class);
+                null, String.class);
     }
 
     /**
@@ -87,7 +87,7 @@ public class HarvestAgentClient extends AbstractRestClient implements HarvestAge
 
         RestTemplate restTemplate = restTemplateBuilder.build();
         restTemplate.postForObject(uriComponentsBuilder.buildAndExpand(pathVariables).toUri(),
-                null, Void.class);
+                null, String.class);
     }
 
     /**
@@ -99,7 +99,7 @@ public class HarvestAgentClient extends AbstractRestClient implements HarvestAge
 
         RestTemplate restTemplate = restTemplateBuilder.build();
         restTemplate.postForObject(uriComponentsBuilder.buildAndExpand(pathVariables).toUri(),
-                null, Void.class);
+                null, String.class);
     }
 
     /**
@@ -111,7 +111,7 @@ public class HarvestAgentClient extends AbstractRestClient implements HarvestAge
 
         RestTemplate restTemplate = restTemplateBuilder.build();
         restTemplate.postForObject(uriComponentsBuilder.buildAndExpand(pathVariables).toUri(),
-                null, Void.class);
+                null, String.class);
     }
 
     /**
@@ -131,7 +131,7 @@ public class HarvestAgentClient extends AbstractRestClient implements HarvestAge
 
         RestTemplate restTemplate = restTemplateBuilder.build();
         restTemplate.postForObject(uriComponentsBuilder.buildAndExpand(pathVariables).toUri(),
-                null, Void.class);
+                null, String.class);
     }
 
     /**
@@ -142,7 +142,7 @@ public class HarvestAgentClient extends AbstractRestClient implements HarvestAge
 
         RestTemplate restTemplate = restTemplateBuilder.build();
         restTemplate.postForObject(uriComponentsBuilder.buildAndExpand().toUri(),
-                null, Void.class);
+                null, String.class);
     }
 
     /**
@@ -153,7 +153,7 @@ public class HarvestAgentClient extends AbstractRestClient implements HarvestAge
 
         RestTemplate restTemplate = restTemplateBuilder.build();
         restTemplate.postForObject(uriComponentsBuilder.buildAndExpand().toUri(),
-                null, Void.class);
+                null, String.class);
     }
 
     /**
@@ -201,7 +201,7 @@ public class HarvestAgentClient extends AbstractRestClient implements HarvestAge
         // exception on the client.
         RestTemplate restTemplate = restTemplateBuilder.build();
         restTemplate.postForObject(uriComponentsBuilder.buildAndExpand().toUri(),
-                null, Void.class);
+                null, String.class);
     }
 
     /**
@@ -216,7 +216,7 @@ public class HarvestAgentClient extends AbstractRestClient implements HarvestAge
 
         RestTemplate restTemplate = restTemplateBuilder.build();
         restTemplate.postForObject(uriComponentsBuilder.buildAndExpand(pathVariables).toUri(),
-                request, Void.class);
+                request, String.class);
     }
 
     /**
@@ -228,7 +228,7 @@ public class HarvestAgentClient extends AbstractRestClient implements HarvestAge
         UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.fromHttpUrl(getUrl(HarvestAgentPaths.PURGE_ABORTED_TARGET_INSTANCES));
 
         RestTemplate restTemplate = restTemplateBuilder.build();
-        restTemplate.postForObject(uriComponentsBuilder.buildAndExpand().toUri(), request, Void.class);
+        restTemplate.postForObject(uriComponentsBuilder.buildAndExpand().toUri(), request, String.class);
     }
 
     public boolean isValidProfile(String profile) {

--- a/webcurator-core/src/main/java/org/webcurator/core/harvester/coordinator/HarvestCoordinatorImpl.java
+++ b/webcurator-core/src/main/java/org/webcurator/core/harvester/coordinator/HarvestCoordinatorImpl.java
@@ -779,19 +779,22 @@ public class HarvestCoordinatorImpl implements HarvestCoordinator {
 		Long tiOid = aTargetInstance.getOid();
 		if (!harvestAgentManager.lock(tiOid))
 			return;
-		log.info("Obtained lock for ti " + tiOid);
+		try {
+			log.info("Obtained lock for ti " + tiOid);
 
-		if (TargetInstance.STATE_SCHEDULED.equals(aTargetInstance.getState())) {
-			ti = loadTargetInstance(tiOid);
-			approved = isTargetApproved(ti);
-		}
+			if (TargetInstance.STATE_SCHEDULED.equals(aTargetInstance.getState())) {
+				ti = loadTargetInstance(tiOid);
+				approved = isTargetApproved(ti);
+			}
 
-		if (approved) {
-			queueApprovedHarvest(aTargetInstance, ti, tiOid);
+			if (approved) {
+				queueApprovedHarvest(aTargetInstance, ti, tiOid);
+			}
+		} finally {
+			// release the lock
+			harvestAgentManager.unLock(tiOid);
+			log.info("Released lock for ti " + tiOid);
 		}
-		// release the lock
-		harvestAgentManager.unLock(tiOid);
-		log.info("Released lock for ti " + tiOid);
 	}
 
 	private void queueApprovedHarvest(QueuedTargetInstanceDTO queuedTargetInstance, TargetInstance ti, Long tiOid) {

--- a/webcurator-core/src/main/java/org/webcurator/core/store/DigitalAssetStoreClient.java
+++ b/webcurator-core/src/main/java/org/webcurator/core/store/DigitalAssetStoreClient.java
@@ -46,7 +46,7 @@ public class DigitalAssetStoreClient extends AbstractRestClient implements Digit
             URI uri=uriComponentsBuilder.buildAndExpand(pathVariables).toUri();
 
             RestTemplate restTemplate = restTemplateBuilder.build();
-            restTemplate.postForObject(uri, request, Void.class);
+            restTemplate.postForObject(uri, request, String.class);
         } catch (Exception e) {
             log.error(e.getMessage());
             throw new DigitalAssetStoreException(e);

--- a/webcurator-core/src/main/java/org/webcurator/core/store/IndexerBase.java
+++ b/webcurator-core/src/main/java/org/webcurator/core/store/IndexerBase.java
@@ -118,7 +118,7 @@ public abstract class IndexerBase implements RunnableIndex {
 
         Map<String, Long> pathVariables = ImmutableMap.of("harvest-result-oid", harvestResultOid);
         restTemplate.postForObject(uriComponentsBuilder.buildAndExpand(pathVariables).toUri(),
-                null, Void.class);
+                null, String.class);
     }
 
     @Override

--- a/webcurator-core/src/main/java/org/webcurator/core/store/WCTIndexer.java
+++ b/webcurator-core/src/main/java/org/webcurator/core/store/WCTIndexer.java
@@ -160,7 +160,7 @@ public class WCTIndexer extends IndexerBase
             UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.fromHttpUrl(getUrl(HarvestCoordinatorPaths.ADD_HARVEST_RESULT));
 
             Map<String, Long> pathVariables = ImmutableMap.of("harvest-result-oid", harvestResultOid);
-            restTemplate.postForObject(uriComponentsBuilder.buildAndExpand(pathVariables).toUri(), request, Void.class);
+            restTemplate.postForObject(uriComponentsBuilder.buildAndExpand(pathVariables).toUri(), request, String.class);
         }catch (JsonProcessingException e){
             log.error("Parsing json failed.");
             log.error(e);
@@ -189,7 +189,7 @@ public class WCTIndexer extends IndexerBase
             UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.fromHttpUrl(getUrl(HarvestCoordinatorPaths.ADD_HARVEST_RESOURCES));
 
             Map<String, Long> pathVariables = ImmutableMap.of("harvest-result-oid", harvestResultOid);
-            restTemplate.postForObject(uriComponentsBuilder.buildAndExpand(pathVariables).toUri(), request, Void.class);
+            restTemplate.postForObject(uriComponentsBuilder.buildAndExpand(pathVariables).toUri(), request, String.class);
         }catch (JsonProcessingException e){
             log.error("Parsing json failed.");
             log.error(e);

--- a/webcurator-harvest-agent-h1/src/main/java/org/webcurator/core/harvester/coordinator/HarvestCoordinatorNotifier.java
+++ b/webcurator-harvest-agent-h1/src/main/java/org/webcurator/core/harvester/coordinator/HarvestCoordinatorNotifier.java
@@ -54,7 +54,7 @@ public class HarvestCoordinatorNotifier extends AbstractRestClient implements Ha
 
         HttpEntity<String> request = this.createHttpRequestEntity(aStatus);
 
-        restTemplate.postForObject(uri, request, Void.class);
+        restTemplate.postForObject(uri, request, String.class);
         log.debug("WCT: End of heartbeat");
     }
 
@@ -76,7 +76,7 @@ public class HarvestCoordinatorNotifier extends AbstractRestClient implements Ha
             UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.fromHttpUrl(getUrl(HarvestCoordinatorPaths.HARVEST_COMPLETE));
             URI uri = uriComponentsBuilder.buildAndExpand().toUri();
 
-            restTemplate.postForObject(uri, request, Void.class);
+            restTemplate.postForObject(uri, request, String.class);
 
             log.debug("WCT: End of HarvestComplete");
         }
@@ -102,7 +102,7 @@ public class HarvestCoordinatorNotifier extends AbstractRestClient implements Ha
                     .queryParam("notification-category", notificationCategory)
                     .queryParam("message-type", aMessageType);
 
-            restTemplate.postForObject(uriComponentsBuilder.buildAndExpand().toUri(), null, Void.class);
+            restTemplate.postForObject(uriComponentsBuilder.buildAndExpand().toUri(), null, String.class);
 
             log.debug("WCT: End of notification");
         }

--- a/webcurator-harvest-agent-h3/src/main/java/org/webcurator/core/harvester/agent/HarvestAgentH3.java
+++ b/webcurator-harvest-agent-h3/src/main/java/org/webcurator/core/harvester/agent/HarvestAgentH3.java
@@ -373,8 +373,6 @@ public class HarvestAgentH3 extends AbstractHarvestAgent implements LogProvider 
             log.info("Getting digital assets to send to store for job " + aJob);
 
             try {
-                // BE AWARE - if a harvest is stopped before any warcs are written then a null pointer exception can be thrown
-                // when getting the file list of the warc dir, because the warc dir may not exist -causing an infinite loop.
                 File[] fileList = getFileArray(das, new NegateFilter(new ExtensionFileFilter(Constants.EXTN_OPEN_ARC)));
                 int numberOfFiles = fileList.length;
 

--- a/webcurator-harvest-agent-h3/src/main/java/org/webcurator/core/harvester/agent/HarvestAgentH3.java
+++ b/webcurator-harvest-agent-h3/src/main/java/org/webcurator/core/harvester/agent/HarvestAgentH3.java
@@ -289,15 +289,20 @@ public class HarvestAgentH3 extends AbstractHarvestAgent implements LogProvider 
         return toFileArray(getFileList(baseDir, filters));
     }
 
+    /**
+     * Returns empty list if the input directory does not exist (sometimes a crawl does not result in
+     * a WARC file, in which case the warcs subdirectory of the H3 job directory will not exist)
+     */
     private List<File> getFileList(File baseDir, FileFilter... filters) {
         List<File> l = new LinkedList<File>();
         File[] files = baseDir.listFiles();
-        //TODO - What if no warcs are generated? This throws null pointer otherwise
-        for (File f : files) {
-            for (FileFilter filter : filters) {
-                if (filter.accepts(f)) {
-                    l.add(f);
-                    break;
+        if (files != null) {
+            for (File f : files) {
+                for (FileFilter filter : filters) {
+                    if (filter.accepts(f)) {
+                        l.add(f);
+                        break;
+                    }
                 }
             }
         }

--- a/webcurator-harvest-agent-h3/src/main/java/org/webcurator/core/harvester/agent/HarvesterH3.java
+++ b/webcurator-harvest-agent-h3/src/main/java/org/webcurator/core/harvester/agent/HarvesterH3.java
@@ -218,7 +218,13 @@ public class HarvesterH3 implements Harvester {
                     if (h3job.crawlControllerState.equals("NASCENT") && !h3job.isLaunchable) {
                         status.setStatus("Could not launch job - Fatal InitializationException");
                     } else if (h3job.crawlControllerState.equals("FINISHED") || h3job.crawlControllerState.equals("STOPPING")) {
-                        status.setStatus("Finished");
+                        // if there's no data, log and append diagnostic to state string
+                        if (h3job.sizeTotalsReport.total == 0) {
+                            log.warn(String.format("Finished crawl job %s without data", h3job.shortName));
+                            status.setStatus("Finished - No data");
+                        } else {
+                            status.setStatus("Finished");
+                        }
                     }
 
                     if (h3job.elapsedReport.elapsedMilliseconds > 0) {

--- a/webcurator-harvest-agent-h3/src/main/java/org/webcurator/core/harvester/agent/HarvesterH3.java
+++ b/webcurator-harvest-agent-h3/src/main/java/org/webcurator/core/harvester/agent/HarvesterH3.java
@@ -630,7 +630,7 @@ public class HarvesterH3 implements Harvester {
             if (jobStatus.statusDescription.equals("Ready")) {
                 log.info("Launching H3 job " + aJobName + ".....");
                 heritrix.launchJob(aJobName);
-                jobStatus = heritrix.waitForJobState(aJobName, Heritrix3Wrapper.CrawlControllerState.PAUSED, 5, 1000).job;
+                jobStatus = heritrix.waitForJobState(aJobName, Heritrix3Wrapper.CrawlControllerState.PAUSED, 50, 1000).job;
             } else {
                 log.error("Failed to start harvester " + name + ": Could not launch H3 job.");
                 throw new HarvesterException("Failed to start harvester " + name + ": Could not launch H3 job.");

--- a/webcurator-harvest-agent-h3/src/main/java/org/webcurator/core/harvester/agent/schedule/HarvestAgentHeartBeatJob.java
+++ b/webcurator-harvest-agent-h3/src/main/java/org/webcurator/core/harvester/agent/schedule/HarvestAgentHeartBeatJob.java
@@ -78,8 +78,8 @@ public class HarvestAgentHeartBeatJob extends QuartzJobBean {
                     }
 
                     // Schedule the job completion process to be run.
-                    else if (jobStatus.equals("Finished") || jobStatus.equals("Could not launch job - Fatal InitializationException")) {
-                        if(log.isDebugEnabled()){
+                    else if (jobStatus.startsWith("Finished") || jobStatus.equals("Could not launch job - Fatal InitializationException")) {
+                        if(log.isDebugEnabled()) {
                             log.debug("HeartBeatJob:H3Poll - job FINISHED: " + job.getJobName() + ". status: " + jobStatus);
                         }
                         SchedulerUtil.scheduleHarvestCompleteJob(job.getJobName());

--- a/webcurator-harvest-agent-h3/src/main/java/org/webcurator/core/harvester/coordinator/HarvestCoordinatorNotifier.java
+++ b/webcurator-harvest-agent-h3/src/main/java/org/webcurator/core/harvester/coordinator/HarvestCoordinatorNotifier.java
@@ -64,7 +64,7 @@ public class HarvestCoordinatorNotifier extends AbstractRestClient implements Ha
 
             HttpEntity<String> request = this.createHttpRequestEntity(aStatus);
 
-            restTemplate.postForObject(uri, request, Void.class);
+            restTemplate.postForObject(uri, request, String.class);
             log.debug("WCT: End of heartbeat");
         } catch (Exception ex) {
             log.error("Heartbeat Notification failed : " + ex.getMessage(), ex);
@@ -83,7 +83,7 @@ public class HarvestCoordinatorNotifier extends AbstractRestClient implements Ha
                 UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.fromHttpUrl(getUrl(HarvestCoordinatorPaths.RECOVERY));
                 URI uri = uriComponentsBuilder.buildAndExpand().toUri();
 
-                restTemplate.postForObject(uri, request, Void.class);
+                restTemplate.postForObject(uri, request, String.class);
                 log.debug("WCT: End of requestRecovery");
 
                 setAttemptRecovery("false");
@@ -109,6 +109,7 @@ public class HarvestCoordinatorNotifier extends AbstractRestClient implements Ha
             URI uri = uriComponentsBuilder.buildAndExpand().toUri();
 
             restTemplate.postForObject(uri, request, String.class);
+            log.debug("WCT: End of requestRecovery");
 
             log.debug("WCT: End of HarvestComplete");
         } catch (Exception ex) {
@@ -130,7 +131,7 @@ public class HarvestCoordinatorNotifier extends AbstractRestClient implements Ha
                     .queryParam("notification-category", notificationCategory)
                     .queryParam("message-type", aMessageType);
 
-            restTemplate.postForObject(uriComponentsBuilder.buildAndExpand().toUri(), null, Void.class);
+            restTemplate.postForObject(uriComponentsBuilder.buildAndExpand().toUri(), null, String.class);
 
             log.debug("WCT: End of notification");
         } catch (Exception ex) {

--- a/webcurator-harvest-agent-h3/src/main/java/org/webcurator/core/harvester/coordinator/HarvestCoordinatorNotifier.java
+++ b/webcurator-harvest-agent-h3/src/main/java/org/webcurator/core/harvester/coordinator/HarvestCoordinatorNotifier.java
@@ -109,7 +109,6 @@ public class HarvestCoordinatorNotifier extends AbstractRestClient implements Ha
             URI uri = uriComponentsBuilder.buildAndExpand().toUri();
 
             restTemplate.postForObject(uri, request, String.class);
-            log.debug("WCT: End of requestRecovery");
 
             log.debug("WCT: End of HarvestComplete");
         } catch (Exception ex) {

--- a/webcurator-harvest-agent-h3/src/main/java/org/webcurator/core/harvester/coordinator/HarvestCoordinatorNotifier.java
+++ b/webcurator-harvest-agent-h3/src/main/java/org/webcurator/core/harvester/coordinator/HarvestCoordinatorNotifier.java
@@ -108,7 +108,7 @@ public class HarvestCoordinatorNotifier extends AbstractRestClient implements Ha
             UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.fromHttpUrl(getUrl(HarvestCoordinatorPaths.HARVEST_COMPLETE));
             URI uri = uriComponentsBuilder.buildAndExpand().toUri();
 
-            restTemplate.postForObject(uri, request, Void.class);
+            restTemplate.postForObject(uri, request, String.class);
 
             log.debug("WCT: End of HarvestComplete");
         } catch (Exception ex) {

--- a/webcurator-store/src/main/java/org/webcurator/core/store/arc/ArcDigitalAssetStoreService.java
+++ b/webcurator-store/src/main/java/org/webcurator/core/store/arc/ArcDigitalAssetStoreService.java
@@ -1297,7 +1297,7 @@ public class ArcDigitalAssetStoreService implements DigitalAssetStore, LogProvid
 
         Map<String, Long> pathVariables = ImmutableMap.of("target-instance-oid", targetInstanceOid);
         restTemplate.postForObject(uriComponentsBuilder.buildAndExpand(pathVariables).toUri(),
-                null, Void.class);
+                null, String.class);
     }
 
     private void failedArchiving(Long targetInstanceOid, String message) {
@@ -1308,7 +1308,7 @@ public class ArcDigitalAssetStoreService implements DigitalAssetStore, LogProvid
 
         Map<String, Long> pathVariables = ImmutableMap.of("target-instance-oid", targetInstanceOid);
         restTemplate.postForObject(uriComponentsBuilder.buildAndExpand(pathVariables).toUri(),
-                null, Void.class);
+                null, String.class);
     }
 
     public CustomDepositFormResultDTO getCustomDepositFormDetails(

--- a/webcurator-store/src/main/java/org/webcurator/core/store/arc/ManualEnd.java
+++ b/webcurator-store/src/main/java/org/webcurator/core/store/arc/ManualEnd.java
@@ -119,7 +119,7 @@ public class ManualEnd {
                 .queryParam("harvest-result", harvestResultDTO);
 
         restTemplate.postForObject(uriComponentsBuilder.buildAndExpand().toUri(),
-                null, Void.class);
+                null, String.class);
     }
 
     private static void syntax() {

--- a/webcurator-webapp/build.gradle
+++ b/webcurator-webapp/build.gradle
@@ -83,6 +83,9 @@ dependencies {
 
 }
 
+// just an alias
+task install(dependsOn: ['bootWar', 'publishToMavenLocal'])
+ 
 war {
     includeEmptyDirs = false
 }


### PR DESCRIPTION
When a crawl job finished with no warc files, its target instance would remain in the Stopping state forever, because of a null pointer. I've now changed it so the target instance enters the Harvested state, with harvester status "Finished - No data".

There's also a few tweaks to the gradle files: you can now do "grade install" at the top level to build all modules and publish them in your local maven repo.