### PR TITLE
Counters 'URLs' and '% Failed' on the queue page were not being updated

### DIFF
--- a/webcurator-core/src/main/java/org/webcurator/domain/model/core/HarvesterStatus.java
+++ b/webcurator-core/src/main/java/org/webcurator/domain/model/core/HarvesterStatus.java
@@ -75,10 +75,10 @@ public class HarvesterStatus {
     private String heritrixVersion;
     /** the URLs downloaded successfully (derived field needed for sorting) **/
     @Formula("HS_URLS_DOWN-HS_URLS_FAILED")
-    private transient long urlsSucceeded;
+    private long urlsSucceeded;
     /** the percentage of URLs that failed to download successfully (derived field needed for sorting) **/
     @Formula("HS_URLS_FAILED/((HS_URLS_DOWN+0.00001)/100)")
-    private transient float percentageUrlsFailed;
+    private float percentageUrlsFailed;
     
     /** 
      * Default HarvesterStatus Constructor. 


### PR DESCRIPTION
This was due to the inappropriate use of the 'transient' keyword on the underlying variables.