### PR TITLE
Java 9 and Java 11 compatibility

### DIFF
--- a/webcurator-harvest-agent-h3/build.gradle
+++ b/webcurator-harvest-agent-h3/build.gradle
@@ -25,6 +25,8 @@ dependencies {
     //compile 'com.sun.jmx:jmxri:1.2.1'
     compile 'log4j:log4j:1.2.17'
     compile 'org.quartz-scheduler:quartz:2.3.1'
+	compile 'com.sun.xml.bind:jaxb-impl:2.3.2'
+	compile 'com.sun.xml.bind:jaxb-core:2.3.0'
     compile 'org.webcurator:webcurator-core:3.0.0-SNAPSHOT'
     compile 'org.netarchivesuite:heritrix3-wrapper:1.0.3'
     testCompile 'junit:junit:4.12'

--- a/webcurator-submit-to-rosetta/build.gradle
+++ b/webcurator-submit-to-rosetta/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     compile 'org.netpreserve.commons:webarchive-commons:1.1.8'
     compile 'commons-net:commons-net:1.4.1'
     compile 'log4j:log4j:1.2.17'
+	compile 'com.sun.xml.ws:jaxws-ri:2.3.2'
     testCompile 'org.jmock:jmock:2.4.0'
     testCompile 'junit:junit:4.12'
     testCompile 'jmock:jmock-cglib:1.2.0'


### PR DESCRIPTION
Tested WCT compatibility with OpenJDK 9.0.4 and OpenJDK 11.0.8 as I was looking at the documentation updates.

Only minor changes needed to work with Java 9 and 11, needed to explicitly include jaxb and jax-ws dependencies for harvest-agent-h3 and submit-to-rosetta modules.

To test I did the following:

-  installed both JDKs, 
- configured them as the default in JAVA_HOME and PATH environment variables
- updated all the relevant gradle.build files, changing sourceCompatibility and targetCompatibility to 1.9 or 11
- ran gradle clean install
- tested a basic harvest workflow, an H3 crawl, checking logs, then reviewing and pruning. All other screens worked fine that I viewed and/or saved.

NOTE:

- I compiled harvest-agent-h1 successfully with Java 9 and 11, but did not run a harvest using it.
- I did not change the JDK that H3 was running on, was still JDK 8.