### PR TITLE
Restore customization of bean configurations

### DIFF
--- a/webcurator-harvest-agent-h3/src/main/java/org/webcurator/harvestagent/h3/webapp/beans/config/AgentConfig.java
+++ b/webcurator-harvest-agent-h3/src/main/java/org/webcurator/harvestagent/h3/webapp/beans/config/AgentConfig.java
@@ -33,6 +33,7 @@ import org.webcurator.core.util.ApplicationContextFactory;
 import javax.annotation.PostConstruct;
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
@@ -129,6 +130,10 @@ public class AgentConfig {
     @Value("${harvestAgent.attemptHarvestRecovery}")
     private String harvestAgentAttemptHarvestRecovery;
 
+    @Value("${harvestAgent.allowedAgencies}")
+    private String allowedAgencies;
+
+
     // The host protocol type of the digital asset store.
     @Value("${digitalAssetStore.scheme}")
     private String digitalAssetStoreScheme;
@@ -220,7 +225,13 @@ public class AgentConfig {
         bean.setName(harvestAgentName);
         bean.setProvenanceNote(harvestAgentProvenanceNote);
         bean.setAlertThreshold(harvestAgentAlertThreshold);
-        bean.setAllowedAgencies(new ArrayList());
+        if(allowedAgencies.isEmpty() || allowedAgencies == null){
+            bean.setAllowedAgencies(new ArrayList());
+        }
+        else{
+            List<String> splitAgencies = Arrays.asList(allowedAgencies.split("\\s*,\\s*"));
+            bean.setAllowedAgencies(new ArrayList<String>(splitAgencies));
+        }
         bean.setDigitalAssetStore(digitalAssetStore());
         //bean.setHarvestCoordinatorNotifier(harvestCoordinatorNotifier());
 

--- a/webcurator-harvest-agent-h3/src/main/resources/wct-agent.properties
+++ b/webcurator-harvest-agent-h3/src/main/resources/wct-agent.properties
@@ -46,6 +46,10 @@ harvestCoordinatorNotifier.protocol=${core.protocol}
 # the port that the core is listening on for http connections 
 harvestCoordinatorNotifier.port=${core.port}
 
+# Allowed Agencies
+## A Comma separated list of WCT Agencies that are allowed to harvest with this Agent.
+## An empty list, allows any agency to harvest.
+harvestAgent.allowedAgencies=
 
 #DigitalAssetStore
 # the host protocol type of the digital asset store

--- a/webcurator-webapp/src/main/java/org/webcurator/webapp/beans/config/BaseConfig.java
+++ b/webcurator-webapp/src/main/java/org/webcurator/webapp/beans/config/BaseConfig.java
@@ -256,6 +256,51 @@ public class BaseConfig {
     @Value("${qualityReviewToolController.webArchiveTarget}")
     private String qualityReviewToolControllerWebArchiveTarget;
 
+    @Value("${crawlPoliteness.polite.delayFactor}")
+    private double crawlPolitenessPoliteDelayFactor;
+
+    @Value("${crawlPoliteness.polite.minDelayMs}")
+    private long crawlPolitenessPoliteMinDelayMs;
+
+    @Value("${crawlPoliteness.polite.MaxDelayMs}")
+    private long crawlPolitenessPoliteMaxDelayMs;
+
+    @Value("${crawlPoliteness.polite.respectCrawlDelayUpToSeconds}")
+    private long crawlPolitenessPoliteRespectCrawlDelay;
+
+    @Value("${crawlPoliteness.polite.maxPerHostBandwidthUsageKbSec}")
+    private long crawlPolitenessPoliteMaxPerHostBandwidth;
+
+    @Value("${crawlPoliteness.medium.delayFactor}")
+    private double crawlPolitenessMediumDelayFactor;
+
+    @Value("${crawlPoliteness.medium.minDelayMs}")
+    private long crawlPolitenessMediumMinDelayMs;
+
+    @Value("${crawlPoliteness.medium.MaxDelayMs}")
+    private long crawlPolitenessMediumMaxDelayMs;
+
+    @Value("${crawlPoliteness.medium.respectCrawlDelayUpToSeconds}")
+    private long crawlPolitenessMediumRespectCrawlDelay;
+
+    @Value("${crawlPoliteness.medium.maxPerHostBandwidthUsageKbSec}")
+    private long crawlPolitenessMediumMaxPerHostBandwidth;
+
+    @Value("${crawlPoliteness.aggressive.delayFactor}")
+    private double crawlPolitenessAggressiveDelayFactor;
+
+    @Value("${crawlPoliteness.aggressive.minDelayMs}")
+    private long crawlPolitenessAggressiveMinDelayMs;
+
+    @Value("${crawlPoliteness.aggressive.MaxDelayMs}")
+    private long crawlPolitenessAggressiveMaxDelayMs;
+
+    @Value("${crawlPoliteness.aggressive.respectCrawlDelayUpToSeconds}")
+    private long crawlPolitenessAggressiveRespectCrawlDelay;
+
+    @Value("${crawlPoliteness.aggressive.maxPerHostBandwidthUsageKbSec}")
+    private long crawlPolitenessAggressiveMaxPerHostBandwidth;
+
     @Autowired
     private ListsConfig listsConfig;
 
@@ -1162,7 +1207,7 @@ public class BaseConfig {
     public PolitenessOptions politePolitenessOptions() {
         // Delay Factor, Min Delay milliseconds, Max Delay milliseconds,
         // Respect crawl delay up to seconds, Max per host bandwidth usage kb/sec
-        return new PolitenessOptions(10.0, 9000L, 90000L, 180L, 400L);
+        return new PolitenessOptions(crawlPolitenessPoliteDelayFactor, crawlPolitenessPoliteMinDelayMs, crawlPolitenessPoliteMaxDelayMs, crawlPolitenessPoliteRespectCrawlDelay, crawlPolitenessPoliteMaxPerHostBandwidth);
     }
 
     @Bean
@@ -1171,7 +1216,7 @@ public class BaseConfig {
     public PolitenessOptions mediumPolitenessOptions() {
         // Delay Factor, Min Delay milliseconds, Max Delay milliseconds,
         // Respect crawl delay up to seconds, Max per host bandwidth usage kb/sec
-        return new PolitenessOptions(5.0, 3000L, 30000L, 30L, 800L);
+        return new PolitenessOptions(crawlPolitenessMediumDelayFactor, crawlPolitenessMediumMinDelayMs, crawlPolitenessMediumMaxDelayMs, crawlPolitenessMediumRespectCrawlDelay, crawlPolitenessMediumMaxPerHostBandwidth);
     }
 
     @Bean
@@ -1180,6 +1225,6 @@ public class BaseConfig {
     public PolitenessOptions aggressivePolitenessOptions() {
         // Delay Factor, Min Delay milliseconds, Max Delay milliseconds,
         // Respect crawl delay up to seconds, Max per host bandwidth usage kb/sec
-        return new PolitenessOptions(1.0, 1000L, 10000L, 2L, 2000L);
+        return new PolitenessOptions(crawlPolitenessAggressiveDelayFactor, crawlPolitenessAggressiveMinDelayMs, crawlPolitenessAggressiveMaxDelayMs, crawlPolitenessAggressiveRespectCrawlDelay, crawlPolitenessAggressiveMaxPerHostBandwidth);
     }
 }

--- a/webcurator-webapp/src/main/resources/wct-webapp.properties
+++ b/webcurator-webapp/src/main/resources/wct-webapp.properties
@@ -168,3 +168,24 @@ createNewTargetInstancesTrigger.repeatInterval=86400000
 
 # the access url to use for the Web Archive to search for a specific target
 qualityReviewToolController.webArchiveTarget=http://www.webarchive.org.uk/ukwa/target/
+
+
+# H3 crawl politeness settings
+
+crawlPoliteness.polite.delayFactor=10.0
+crawlPoliteness.polite.minDelayMs=9000
+crawlPoliteness.polite.MaxDelayMs=90000
+crawlPoliteness.polite.respectCrawlDelayUpToSeconds=180
+crawlPoliteness.polite.maxPerHostBandwidthUsageKbSec=400
+
+crawlPoliteness.medium.delayFactor=5.0
+crawlPoliteness.medium.minDelayMs=3000
+crawlPoliteness.medium.MaxDelayMs=30000
+crawlPoliteness.medium.respectCrawlDelayUpToSeconds=30
+crawlPoliteness.medium.maxPerHostBandwidthUsageKbSec=800
+
+crawlPoliteness.aggressive.delayFactor=1.0
+crawlPoliteness.aggressive.minDelayMs=1000
+crawlPoliteness.aggressive.MaxDelayMs=10000
+crawlPoliteness.aggressive.respectCrawlDelayUpToSeconds=2
+crawlPoliteness.aggressive.maxPerHostBandwidthUsageKbSec=2000


### PR DESCRIPTION
Re-adding customization of the following configurations:

- Crawl politeness (webapp : wct-agent.properties)
    - Tested by changing values in properties file and then checking values when creating a new H3 profile
- Allowed agencies (webcurator-harvest-agent-h3 : wct-agent.properties)
    - Tested by setting values that did and did not match valid agencies in my WCT instance