### PR TITLE
Fix for reports page error

### DIFF
--- a/webcurator-core/src/main/java/org/webcurator/domain/UserRoleDAOImpl.java
+++ b/webcurator-core/src/main/java/org/webcurator/domain/UserRoleDAOImpl.java
@@ -110,7 +110,7 @@ public class UserRoleDAOImpl implements UserRoleDAO {
     
     public List getUsers() {
         Query q = sessionFactory.getCurrentSession().createQuery("Select u from " + User.class.getCanonicalName()
-                                                                    + " u order by u.userName");
+                                                                    + " u order by u.username");
         return q.getResultList();
     }
     


### PR DESCRIPTION
If a user has the permission to view all reports (as opposed to just the reports of their own agency), the reports page returns an error. This is caused by a typo in the JPQL query that is executed in that particular case.

Apparently, I'm also the one who introduced this typo about a year ago ;)