### PR TITLE
Version number issues

### DIFF
--- a/webcurator-webapp/build.gradle
+++ b/webcurator-webapp/build.gradle
@@ -103,16 +103,12 @@ tasks.withType(JavaCompile) {
 
 build.dependsOn war, sourcesJar
 
-def updateVersion() {
-    def configFile = new File(sourceSets.main.output.resourcesDir, 'application.properties')
-    println configFile
-    if (configFile.exists()) {
-        println "updating project.version to '${version}' in ${configFile}"
-        String configContent = configFile.getText('UTF-8')
-        configContent = configContent.replaceAll(/project\.version=.*/, "project.version=${version}")
-        configFile.write(configContent, 'UTF-8')
+
+// update the version number in application.properties
+processResources {
+    filesMatching('application.properties'){
+        filter {
+            it.replaceAll("^project\\.version.*", "project.version=${version}")
+        }
     }
-}
-gradle.buildFinished {
-    updateVersion()
 }

--- a/webcurator-webapp/src/main/webapp/logon.jsp
+++ b/webcurator-webapp/src/main/webapp/logon.jsp
@@ -4,9 +4,8 @@ String basePath = request.getScheme()+"://"+request.getServerName()+":"+request.
 
 String failed = request.getParameter("failed");
 
-//Environment env = EnvironmentFactory.getEnv();
-//String wctAppVersion = env.getApplicationVersion();
-String wctAppVersion = "3.0.0";
+Environment env = EnvironmentFactory.getEnv();
+String wctAppVersion = env.getApplicationVersion();
 %><!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html>
   <head>


### PR DESCRIPTION
This fixes two issues:

* the login page was showing a hard-coded version number
* the version in webapp's application.properties was not being updated during the build

Note also, that master still has version 3.0.0-SNAPSHOT. I'm leaving it unchanged in this PR as well, for clarity.