### PR TITLE
Added Exception catch to HarvestCoordinatorNotifier requestRecovery().

### DIFF
--- a/webcurator-harvest-agent-h3/src/main/java/org/webcurator/core/harvester/coordinator/HarvestCoordinatorNotifier.java
+++ b/webcurator-harvest-agent-h3/src/main/java/org/webcurator/core/harvester/coordinator/HarvestCoordinatorNotifier.java
@@ -93,6 +93,8 @@ public class HarvestCoordinatorNotifier extends AbstractRestClient implements Ha
             log.error("Recovery Request failed.");
 
             throw new HttpClientErrorException(ex.getStatusCode());
+        } catch (Exception ex) {
+            log.error("Recovery Request failed.");
         }
     }
 


### PR DESCRIPTION
To address issue of H3 Harvest Agent not connecting to Webapp, if the Agent is started before the Webapp and fails to connect.