### PR TITLE
Made the mets.xml to contain only primary seed URL

### DIFF
--- a/webcurator-core/src/main/java/org/webcurator/core/archive/SipBuilder.java
+++ b/webcurator-core/src/main/java/org/webcurator/core/archive/SipBuilder.java
@@ -175,6 +175,9 @@ public class SipBuilder {
 		
 		buff.append("  <wct:Seeds>\n");
 		for(Seed seed: targetManager.getSeeds(inst)) {
+			if (!seed.isPrimary()){
+				continue;
+			}
 			buff.append("    <wct:Seed>\n");
 			buff.append("      <wct:SeedURL>" + es(seed.getSeed()) + "</wct:SeedURL>\n");
 			buff.append("      <wct:SeedType>" + es(seed.isPrimary() ? "Primary" : "Secondary") + "</wct:SeedType>\n");
@@ -260,8 +263,11 @@ public class SipBuilder {
 			
 			
 			buff.append("    <wct:SeedsURLs>\n");
-			for(String seed : perm.getSeeds()) {
-				buff.append("      <wct:SeedURL>" + es(seed) + "</wct:SeedURL>\n");				
+			for(Seed seed : perm.getSeeds()) {
+				if (!seed.isPrimary()){
+					continue;
+				}
+				buff.append("      <wct:SeedURL>" + es(seed.getSeed()) + "</wct:SeedURL>\n");
 			}
 			buff.append("    </wct:SeedsURLs>\n");
 			

--- a/webcurator-core/src/main/java/org/webcurator/core/targets/TargetManager.java
+++ b/webcurator-core/src/main/java/org/webcurator/core/targets/TargetManager.java
@@ -1533,7 +1533,7 @@ public class TargetManager {
 						psdto = new PermissionSeedDTO(p);
 					}
 
-					psdto.getSeeds().add(seed.getSeed());
+					psdto.getSeeds().add(seed);
 
 					permissions.put(psdto.getPermissionOid(), psdto);
 				}

--- a/webcurator-core/src/main/java/org/webcurator/domain/model/dto/PermissionSeedDTO.java
+++ b/webcurator-core/src/main/java/org/webcurator/domain/model/dto/PermissionSeedDTO.java
@@ -18,6 +18,7 @@ package org.webcurator.domain.model.dto;
 import java.util.HashSet;
 
 import org.webcurator.domain.model.core.Permission;
+import org.webcurator.domain.model.core.Seed;
 
 /**
  * DTO object for grouping seeds with their permissions
@@ -29,12 +30,12 @@ public class PermissionSeedDTO {
 	/** the permission associated. */
 	private Permission permission;
 	/** the seed urls associated with the permission. */
-	private HashSet<String> seeds;
+	private HashSet<Seed> seeds;
 	
 	public PermissionSeedDTO(Permission aPermission) {
 		permissionOid = aPermission.getOid();
 		permission = aPermission;
-		seeds = new HashSet<String>();
+		seeds = new HashSet<Seed>();
 		
 		permission.getSite();
 		permission.getAuthorisingAgent();
@@ -67,13 +68,13 @@ public class PermissionSeedDTO {
 	/**
 	 * @return the seeds
 	 */
-	public HashSet<String> getSeeds() {
+	public HashSet<Seed> getSeeds() {
 		return seeds;
 	}
 	/**
 	 * @param seeds the seeds to set
 	 */
-	public void setSeeds(HashSet<String> seeds) {
+	public void setSeeds(HashSet<Seed> seeds) {
 		this.seeds = seeds;
 	}	
 }


### PR DESCRIPTION
Simplified the mets.xml of harvests, to contain primary seed only: the footprint of harvest tasks, such as permissions and seeds were frozen and were saved in DB. This PR still keeps the data in DB not changed, and filters out the primary seed URL when generating the mets.xml.