### PR TITLE
Readthedocs Update

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,14 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: webcurator-docs/conf.py


### PR DESCRIPTION
Readthedocs now requires a dedicated configuration file for builds.
See https://blog.readthedocs.com/migrate-configuration-v2/

Will need to merge PR to confirm the readthedocs builds are working again