### PR TITLE
3.1.5/bug fix vis

### DIFF
--- a/webcurator-core/src/main/java/org/webcurator/core/visualization/networkmap/service/NetworkMapClientLocal.java
+++ b/webcurator-core/src/main/java/org/webcurator/core/visualization/networkmap/service/NetworkMapClientLocal.java
@@ -229,13 +229,13 @@ public class NetworkMapClientLocal implements NetworkMapClient {
             return NetworkMapResult.getDBMissingErrorResult();
         }
         NetworkMapResult result = new NetworkMapResult();
-        List<NetworkMapNodeUrlEntity> urls = searchUrlDTOs(db, searchCommand);
-        if (urls.size() > MAX_SEARCH_SIZE) {
-            String warning = "Cannot display all URLs, please reduce the results using narrow search conditions.";
-            log.warn(warning);
-            result.setRspCode(NetworkMapResult.RSP_CODE_WARN);
-            result.setRspMsg(warning);
-        }
+        List<NetworkMapNodeUrlEntity> urls = searchUrlDTOs(db, searchCommand, true);
+//        if (urls.size() > MAX_SEARCH_SIZE) {
+//            String warning = "Cannot display all URLs, please reduce the results using narrow search conditions.";
+//            log.warn(warning);
+//            result.setRspCode(NetworkMapResult.RSP_CODE_WARN);
+//            result.setRspMsg(warning);
+//        }
 
         String json = this.obj2Json(urls);
         urls.clear();
@@ -250,10 +250,10 @@ public class NetworkMapClientLocal implements NetworkMapClient {
             return null;
         }
 
-        return searchUrlDTOs(db, searchCommand);
+        return searchUrlDTOs(db, searchCommand, true);
     }
 
-    public List<NetworkMapNodeUrlEntity> searchUrlDTOs(BDBRepoHolder db, NetworkMapServiceSearchCommand searchCommand) {
+    public List<NetworkMapNodeUrlEntity> searchUrlDTOs(BDBRepoHolder db, NetworkMapServiceSearchCommand searchCommand, boolean allowBigDatasets) {
         if (searchCommand == null) {
             searchCommand = new NetworkMapServiceSearchCommand();
         }
@@ -268,7 +268,7 @@ public class NetworkMapClientLocal implements NetworkMapClient {
                 continue;
             }
             urls.add(urlEntity);
-            if (urls.size() > MAX_SEARCH_SIZE) {
+            if (!allowBigDatasets && urls.size() > MAX_SEARCH_SIZE) {
                 break;
             }
         }
@@ -481,12 +481,12 @@ public class NetworkMapClientLocal implements NetworkMapClient {
         }
 
         NetworkMapResult result = new NetworkMapResult();
-        if (payload.size() > MAX_SEARCH_SIZE) {
-            String warning = "Cannot modify all selected URLs, please reduce the results.";
-            log.warn(warning);
-            result.setRspCode(NetworkMapResult.RSP_CODE_WARN);
-            result.setRspMsg(warning);
-        }
+//        if (payload.size() > MAX_SEARCH_SIZE) {
+//            String warning = "Cannot modify all selected URLs, please reduce the results.";
+//            log.warn(warning);
+//            result.setRspCode(NetworkMapResult.RSP_CODE_WARN);
+//            result.setRspMsg(warning);
+//        }
 
         String json = this.obj2Json(payload);
         payload.forEach(NetworkMapNodeUrlEntity::clear);
@@ -545,13 +545,13 @@ public class NetworkMapClientLocal implements NetworkMapClient {
         }
 
         NetworkMapResult result = new NetworkMapResult();
-        if (payload.size() > MAX_SEARCH_SIZE) {
-            String warning = "Cannot modify all selected URLs, please reduce the results.";
-
-            log.warn(warning);
-            result.setRspCode(NetworkMapResult.RSP_CODE_WARN);
-            result.setRspMsg(warning);
-        }
+//        if (payload.size() > MAX_SEARCH_SIZE) {
+//            String warning = "Cannot modify all selected URLs, please reduce the results.";
+//
+//            log.warn(warning);
+//            result.setRspCode(NetworkMapResult.RSP_CODE_WARN);
+//            result.setRspMsg(warning);
+//        }
 
         String json = this.obj2Json(payload);
         payload.forEach(ModifyRowFullData::clear);
@@ -578,19 +578,19 @@ class CompiledSearchCommand {
     public static CompiledSearchCommand getInstance(NetworkMapServiceSearchCommand searchCommand) {
         CompiledSearchCommand compiledSearchCommand = new CompiledSearchCommand(searchCommand.getDomainLevel());
 
-        if (searchCommand.getDomainNames() != null && searchCommand.getDomainNames().size() > 0) {
+        if (searchCommand.getDomainNames() != null && !searchCommand.getDomainNames().isEmpty()) {
             compiledSearchCommand.domainNameCondition = searchCommand.getDomainNames().stream().map(SearchCommandItem::new).collect(Collectors.toList());
         }
 
-        if (searchCommand.getUrlNames() != null && searchCommand.getUrlNames().size() > 0) {
+        if (searchCommand.getUrlNames() != null && !searchCommand.getUrlNames().isEmpty()) {
             compiledSearchCommand.urlNameCondition = searchCommand.getUrlNames().stream().map(SearchCommandItem::new).collect(Collectors.toList());
         }
 
-        if (searchCommand.getContentTypes() != null && searchCommand.getContentTypes().size() > 0) {
+        if (searchCommand.getContentTypes() != null && !searchCommand.getContentTypes().isEmpty()) {
             compiledSearchCommand.contentTypeCondition = searchCommand.getContentTypes().stream().map(SearchCommandItem::new).collect(Collectors.toList());
         }
 
-        if (searchCommand.getStatusCodes() != null && searchCommand.getStatusCodes().size() > 0) {
+        if (searchCommand.getStatusCodes() != null && !searchCommand.getStatusCodes().isEmpty()) {
             compiledSearchCommand.statusCodeCondition = new ArrayList<>(searchCommand.getStatusCodes());
         }
         return compiledSearchCommand;
@@ -610,7 +610,7 @@ class CompiledSearchCommand {
     }
 
     private boolean isIncludedByDomainName(String domainName) {
-        if (domainNameCondition.size() == 0) {
+        if (domainNameCondition.isEmpty()) {
             return true;
         }
 
@@ -623,7 +623,7 @@ class CompiledSearchCommand {
     }
 
     private boolean isIncludedByUrlName(String urlName) {
-        if (urlNameCondition.size() == 0) {
+        if (urlNameCondition.isEmpty()) {
             return true;
         }
 
@@ -636,7 +636,7 @@ class CompiledSearchCommand {
     }
 
     private boolean isIncludedByContentType(String contentType) {
-        if (contentTypeCondition.size() == 0) {
+        if (contentTypeCondition.isEmpty()) {
             return true;
         }
 
@@ -649,7 +649,7 @@ class CompiledSearchCommand {
     }
 
     private boolean isIncludedByStatusCode(int statusCode) {
-        if (statusCodeCondition.size() == 0) {
+        if (statusCodeCondition.isEmpty()) {
             return true;
         }
 

--- a/webcurator-core/src/test/java/org/webcurator/core/visualization/networkmap/NetworkMapUtilTest.java
+++ b/webcurator-core/src/test/java/org/webcurator/core/visualization/networkmap/NetworkMapUtilTest.java
@@ -52,7 +52,7 @@ public class NetworkMapUtilTest extends BaseVisualizationTest {
         BDBRepoHolder db = pool.getInstance(targetInstanceId, harvestResultNumber);
 
         NetworkMapServiceSearchCommand searchCommand = new NetworkMapServiceSearchCommand();
-        List<NetworkMapNodeUrlEntity> networkMapNodeUrlEntityList = localClient.searchUrlDTOs(db, searchCommand);
+        List<NetworkMapNodeUrlEntity> networkMapNodeUrlEntityList = localClient.searchUrlDTOs(db, searchCommand,false);
 
         NetworkMapNodeFolderDTO rootTreeNodeDTO = new NetworkMapNodeFolderDTO();
         networkMapNodeUrlEntityList.forEach(node -> {

--- a/webcurator-webapp/src/main/webapp/spa/tools/networkmap.js
+++ b/webcurator-webapp/src/main/webapp/spa/tools/networkmap.js
@@ -84,7 +84,11 @@ class NetworkMap{
 			condition=source.getSelectedNodes();
 		}
 
-		gPopupModifyHarvest.checkUrls(condition, action);
+        if(action === 'prune'){
+            gPopupModifyHarvest.bulkPrune(condition, action);
+        }else{
+            gPopupModifyHarvest.checkUrls(condition, action);
+        }
 	}
 
 	static contextMenuItemsGrid={

--- a/webcurator-webapp/src/main/webapp/spa/tools/patching-view-hr.html
+++ b/webcurator-webapp/src/main/webapp/spa/tools/patching-view-hr.html
@@ -344,7 +344,7 @@ to get the desired effect
 
         fetchData();
 
-        setInterval(fetchData, 5000);
+        //setInterval(fetchData, 5000);
     });
 </script>
 </body>

--- a/webcurator-webapp/src/main/webapp/spa/tools/patching-view-hr.html
+++ b/webcurator-webapp/src/main/webapp/spa/tools/patching-view-hr.html
@@ -298,7 +298,12 @@ to get the desired effect
         updateCommandTable('#table-body-file-import', gridOptionsCommandImportByFile, data.listToBeImportedByFile);
     }
 
+    var nextAvailable=true;
     function fetchData(){
+        if(!nextAvailable){
+            return;
+        }
+        nextAvailable=false;
         var reqUrl=webContextPath+'/curator/target/patching-hr-view-data?targetInstanceOid='+jobId+'&harvestResultId='+harvestResultId+'&harvestNumber='+harvestResultNumber;
         fetch(reqUrl, { 
             method: 'GET',
@@ -316,6 +321,7 @@ to get the desired effect
                 $('.card').hide();
                 $('#hr-deleted-cover').show();
             }
+            nextAvailable=true;
         });
     }
 
@@ -338,7 +344,7 @@ to get the desired effect
 
         fetchData();
 
-        setInterval(fetchData, 3000);
+        setInterval(fetchData, 5000);
     });
 </script>
 </body>

--- a/webcurator-webapp/src/main/webapp/spa/tools/popup-modify-harvest.js
+++ b/webcurator-webapp/src/main/webapp/spa/tools/popup-modify-harvest.js
@@ -435,7 +435,7 @@ class HierarchyTree{
 		var filterFunc = tree.filterNodes; //tree.filterBranches
 		var option={
 				autoApply: false,   // Re-apply last filter if lazy data is loaded
-				autoExpand: true, // Expand all branches that contain matches while filtered
+				autoExpand: false, // Expand all branches that contain matches while filtered
 				counter: true,     // Show a badge with number of matching child nodes near parent icons
 				fuzzy: false,      // Match single characters in order, e.g. 'fb' will match 'FooBar'
 				hideExpandedCounter: true,  // Hide counter badge if parent is expanded

--- a/webcurator-webapp/src/main/webapp/spa/tools/popup-modify-harvest.js
+++ b/webcurator-webapp/src/main/webapp/spa/tools/popup-modify-harvest.js
@@ -378,8 +378,9 @@ class HierarchyTree{
 	}
 
 	getSelectedNodes(){
+		var treeView=$.ui.fancytree.getTree(this.container);
 		var selData=[];
-		var selNodes = $.ui.fancytree.getTree(this.container).getSelectedNodes();
+		var selNodes = treeView.getSelectedNodes();
 		// var map={};
 		for(var i=0; i<selNodes.length; i++){
 			var treeNode=selNodes[i];
@@ -557,13 +558,13 @@ class PopupModifyHarvest{
 		});
 
 		//Set class for tree view
-		$('.hierachy-tree td').removeClass("tree-row-delete");
-		$('.hierachy-tree td').removeClass("tree-row-recrawl");
-		$('.hierachy-tree td').removeClass("tree-row-file");
+		$('.hierachy-tree tr').removeClass("tree-row-delete");
+		$('.hierachy-tree tr').removeClass("tree-row-recrawl");
+		$('.hierachy-tree tr').removeClass("tree-row-file");
 		for(var key in toBeModifiedDataMap){
 			var classOfTreeRow=this.getTreeNodeStyle(toBeModifiedDataMap[key].option);
 			// console.log('.hierachy-tree tr[idx="' + key + '"] td' + classOfTreeRow);
-			$('.hierachy-tree tr[idx="' + key + '"] td').addClass(classOfTreeRow);
+			$('.hierachy-tree tr[idx="' + key + '"]').addClass(classOfTreeRow);
 		}
 
 		//Set class for grid candidate


### PR DESCRIPTION
Fixed the issues and improved the performance for visualization:
1. Removed the max rows limitation from the grid view of visualization. Related to issue #96: 
2. Improved the performance of UI:
- Did not valid each URLs when put them to the pruning/recrawling candidate page.
- Set the modification flag classes (css classed) to row instead of to td to improve the rendering performance of tree views.
3. Fixed the issue of filter for tree views: for the lazy loading tree views, the nodes will be recursively loaded and expanded when filtering from the views. Disabled the auto expanded properties to figure out this issue.
4. Optimized the timer for progress updating: the users can open the page to inspect the progress of modification of havest results. The UI will polling the status of progress periodically. For huge modification, it will take a long time to get the progress data. Sometimes, the previous polling request wasn't finished then the next polling request was triggered. Optimized the process to start the next polling request only after the previous is finished.
