### PR TITLE
3.1.5/bug fix custom deposit

### DIFF
--- a/webcurator-core/src/main/java/org/webcurator/domain/model/core/CustomDepositFormResultDTO.java
+++ b/webcurator-core/src/main/java/org/webcurator/domain/model/core/CustomDepositFormResultDTO.java
@@ -34,6 +34,12 @@ public class CustomDepositFormResultDTO {
 	 * fetched.
 	 */
 	private String urlForCustomDepositForm;
+
+	/**
+	 * The URL to where the custom form is to be submitted
+	 */
+	private String urlForCustomDepositFormSubmit;
+
 	/**
 	 * HTML contents of the custom deposit form.
 	 */
@@ -93,6 +99,15 @@ public class CustomDepositFormResultDTO {
 	public void setHTMLForCustomDepositForm(String htmlForCustomDepositForm) {
 		this.htmlForCustomDepositForm = htmlForCustomDepositForm;
 	}
+
+	public String getUrlForCustomDepositFormSubmit() {
+		return urlForCustomDepositFormSubmit;
+	}
+
+	public void setUrlForCustomDepositFormSubmit(String urlForCustomDepositFormSubmit) {
+		this.urlForCustomDepositFormSubmit = urlForCustomDepositFormSubmit;
+	}
+
 	public String getProducerId() {
 		return producerId;
 	}

--- a/webcurator-store/src/main/java/org/webcurator/core/archive/dps/DPSArchive.java
+++ b/webcurator-store/src/main/java/org/webcurator/core/archive/dps/DPSArchive.java
@@ -132,6 +132,7 @@ public class DPSArchive extends BaseArchive {
     private List<String> producerIdsOfHtmlSerials = new ArrayList<String>();
     private List<String> ieEntityTypesOfHtmlSerials = new ArrayList<String>();
     private List<String> customDepositFormURLsForHtmlSerialIngest;
+    private List<String> customDepositFormSubmitURLsForHtmlSerialIngest;
     private boolean restrictHTMLSerialAgenciesToHTMLSerialTypes;
     //    private Map<String, Map<String, String>> customDepositFormFieldMaps = new HashMap<String, Map<String, String>>();
     private CustomDepositFormMapping customDepositFormMapping;
@@ -242,6 +243,9 @@ public class DPSArchive extends BaseArchive {
                 response.setCustomDepositFormRequired(true);
                 response.setUrlForCustomDepositForm("/customDepositForms/rosetta_custom_deposit_form_invalid_dctype.jsp");
             }
+        }
+        if (targetTypeIndex >= 0) {
+            response.setUrlForCustomDepositFormSubmit(customDepositFormSubmitURLsForHtmlSerialIngest.get(targetTypeIndex));
         }
         return response;
     }
@@ -600,6 +604,10 @@ public class DPSArchive extends BaseArchive {
 
     public void setCustomDepositFormURLsForHtmlSerialIngest(String customDepositFormURLsForHtmlSerialIngest) {
         this.customDepositFormURLsForHtmlSerialIngest = toList(customDepositFormURLsForHtmlSerialIngest);
+    }
+
+    public void setCustomDepositFormSubmitURLsForHtmlSerialIngest(String customDepositFormSubmitURLsForHtmlSerialIngest) {
+        this.customDepositFormSubmitURLsForHtmlSerialIngest = toList(customDepositFormSubmitURLsForHtmlSerialIngest);
     }
 
     /**

--- a/webcurator-store/src/main/java/org/webcurator/store/webapp/beans/config/DasConfig.java
+++ b/webcurator-store/src/main/java/org/webcurator/store/webapp/beans/config/DasConfig.java
@@ -222,6 +222,9 @@ public class DasConfig {
     @Value("${dpsArchive.htmlSerials.customDepositFormURLs}")
     private String dpsArchiveHtmlSerialsCustomDepositFormURLs;
 
+    @Value("${dpsArchive.htmlSerials.customDepositFormSubmitURLs}")
+    private String dpsArchiveHtmlSerialsCustomDepositFormSubmitURLs;
+
     @Value("${dpsArchive.dnx_open_access}")
     private String dpsArchiveDnxOpenAccess;
 
@@ -525,6 +528,7 @@ public class DasConfig {
         bean.setProducerIdsOfHtmlSerials(dpsArchiveHtmlSerialsProducerIds);
         bean.setIeEntityTypesOfHtmlSerials(dpsArchiveHtmlSerialsIeEntityTypes);
         bean.setCustomDepositFormURLsForHtmlSerialIngest(dpsArchiveHtmlSerialsCustomDepositFormURLs);
+        bean.setCustomDepositFormSubmitURLsForHtmlSerialIngest(dpsArchiveHtmlSerialsCustomDepositFormSubmitURLs);
         bean.setCustomDepositFormMapping(customDepositFormFieldMappings());
         bean.setOmsOpenAccess(dpsArchiveDnxOpenAccess);
         bean.setOmsPublishedRestricted(dpsArchiveDnxPublishedRestricted);

--- a/webcurator-store/src/main/resources/application.properties
+++ b/webcurator-store/src/main/resources/application.properties
@@ -153,6 +153,12 @@ dpsArchive.htmlSerials.targetDCTypes=eSerial
 # - If WCT Core and WCT Digital Asset Store are deployed in the same Tomcat instance, use a relative URL
 # - If they are deployed in different machines or Tomcat instances, use absolute URL based on WCT DAS' host/port.
 dpsArchive.htmlSerials.customDepositFormURLs=http://localhost:${server.port}/customDepositForms/rosetta_alma_custom_deposit_form.jsp
+
+# URLs that Users would use to submit the custom deposit form from browsers for
+# each of the target types, separated by comma.
+# A note on the format of this URL:
+# - If the User's Browser and WCT Digital Asset Store are deployed in the same machine(usually for DEV or Test scenarios), the default value can be used.
+# - If it is deployed behind a Fire Wall or Reverse Proxy, use the URL exposed from the Fire Wall or Reverse Proxy.
 dpsArchive.htmlSerials.customDepositFormSubmitURLs=http://localhost:${server.port}
 
 # The material flow ID for each of the target types, separated by comma.

--- a/webcurator-store/src/main/resources/application.properties
+++ b/webcurator-store/src/main/resources/application.properties
@@ -153,6 +153,7 @@ dpsArchive.htmlSerials.targetDCTypes=eSerial
 # - If WCT Core and WCT Digital Asset Store are deployed in the same Tomcat instance, use a relative URL
 # - If they are deployed in different machines or Tomcat instances, use absolute URL based on WCT DAS' host/port.
 dpsArchive.htmlSerials.customDepositFormURLs=http://localhost:${server.port}/customDepositForms/rosetta_alma_custom_deposit_form.jsp
+dpsArchive.htmlSerials.customDepositFormSubmitURLs=http://localhost:${server.port}
 
 # The material flow ID for each of the target types, separated by comma.
 # There should be one entry for each target type defined above.

--- a/webcurator-store/src/main/webapp/customDepositForms/rosetta_alma_custom_deposit_form.jsp
+++ b/webcurator-store/src/main/webapp/customDepositForms/rosetta_alma_custom_deposit_form.jsp
@@ -420,9 +420,10 @@ function ajaxFunction_internal(requestParams, destinationDiv, asynchronousFlag) 
 	//policy will prevent the request if it is changed to use the configured values.
 	var serverPort = document.getElementById("dasport").value;
 	var serverHost = document.getElementById("dashost").value;
+	var customDepositFormSubmitURL = document.getElementById("customDepositFormSubmitURL").value;
 	var coreBaseUrl = document.getElementById("coreBaseUrl").value;
 
-	xmlhttp.open("POST", "http://" + serverHost + ":" + serverPort + "/digital-asset-store/rosettaInterface", asynchronousFlag);
+	xmlhttp.open("POST", customDepositFormSubmitURL + "/digital-asset-store/rosettaInterface", asynchronousFlag);
 	xmlhttp.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
     xmlhttp.setRequestHeader("Access-Control-Allow-Origin", coreBaseUrl);
     xmlhttp.setRequestHeader("Access-Control-Allow-Methods","GET,POST,OPTIONS");

--- a/webcurator-store/src/test/java/org/webcurator/core/archive/dps/DPSArchiveTest.java
+++ b/webcurator-store/src/test/java/org/webcurator/core/archive/dps/DPSArchiveTest.java
@@ -64,6 +64,8 @@ public class DPSArchiveTest {
         String customFormUrl_eManuscript = "/some/nice/url/eManuscript";
         String customFormUrl_Blog = "/some/nice/url/blog";
         String customFormUrls = customFormUrl_eJournal + ", " + customFormUrl_eManuscript + ", " + customFormUrl_Blog;
+        String customFormSubmitUrls = customFormUrls;
+
         DPSArchive archiver;
         CustomDepositFormResultDTO result;
         CustomDepositFormCriteriaDTO criteria;
@@ -73,6 +75,7 @@ public class DPSArchiveTest {
         // Expect true for the isCustomDepositFormRequired(), a proper value for the URL of custom form.
         archiver = new DPSArchive();
         archiver.setCustomDepositFormURLsForHtmlSerialIngest(customFormUrls);
+        archiver.setCustomDepositFormSubmitURLsForHtmlSerialIngest(customFormSubmitUrls);
         archiver.setTargetDCTypesOfHtmlSerials("HTML Serial Type 1 - eJournals, HTML Serial Type 2 - Manuscripts , HTML Serial Type 3 - Blogs    ");
         archiver.setAgenciesResponsibleForHtmlSerials("   Electronic Journals   ,  Electronic Serials     ");
         criteria = new CustomDepositFormCriteriaDTO();
@@ -89,6 +92,7 @@ public class DPSArchiveTest {
         // Expect true for the isCustomDepositFormRequired(), and "invalid dc type JSP" for the URL of custom form.
         archiver = new DPSArchive();
         archiver.setCustomDepositFormURLsForHtmlSerialIngest(customFormUrls);
+        archiver.setCustomDepositFormSubmitURLsForHtmlSerialIngest(customFormSubmitUrls);
         archiver.setTargetDCTypesOfHtmlSerials("HTML Serial Type 1 - eJournals, HTML Serial Type 2 - Manuscripts , HTML Serial Type 3 - Blogs    ");
         archiver.setAgenciesResponsibleForHtmlSerials("   Electronic Journals   ,  Electronic Serials     ");
         archiver.setRestrictHTMLSerialAgenciesToHTMLSerialTypes("true");
@@ -106,6 +110,7 @@ public class DPSArchiveTest {
         // Expect true for the isCustomDepositFormRequired(), a proper value for the URL of custom form.
         archiver = new DPSArchive();
         archiver.setCustomDepositFormURLsForHtmlSerialIngest(customFormUrls);
+        archiver.setCustomDepositFormSubmitURLsForHtmlSerialIngest(customFormSubmitUrls);
         archiver.setTargetDCTypesOfHtmlSerials("HTML Serial Type 1 - eJournals, HTML Serial Type 2 - Manuscripts , HTML Serial Type 3 - Blogs    ");
         archiver.setAgenciesResponsibleForHtmlSerials("   Electronic Journals   ,  Electronic Serials     ");
         criteria = new CustomDepositFormCriteriaDTO();
@@ -121,6 +126,7 @@ public class DPSArchiveTest {
         // Expect false for the isCustomDepositFormRequired(), null for the URL and HTML of custom form.
         archiver = new DPSArchive();
         archiver.setCustomDepositFormURLsForHtmlSerialIngest(customFormUrls);
+        archiver.setCustomDepositFormSubmitURLsForHtmlSerialIngest(customFormSubmitUrls);
         archiver.setTargetDCTypesOfHtmlSerials("HTML Serial Type 1 - eJournals, HTML Serial Type 2 - Manuscripts , HTML Serial Type 3 - Blogs    ");
         archiver.setAgenciesResponsibleForHtmlSerials("   Electronic Journals   ,  Electronic Serials     ");
         criteria = new CustomDepositFormCriteriaDTO();
@@ -135,6 +141,7 @@ public class DPSArchiveTest {
         // Null criteria object
         archiver = new DPSArchive();
         archiver.setCustomDepositFormURLsForHtmlSerialIngest(customFormUrls);
+        archiver.setCustomDepositFormSubmitURLsForHtmlSerialIngest(customFormSubmitUrls);
         archiver.setTargetDCTypesOfHtmlSerials("HTML Serial Type 1 - eJournals, HTML Serial Type 2 - Manuscripts , HTML Serial Type 3 - Blogs    ");
         archiver.setAgenciesResponsibleForHtmlSerials("   Electronic Journals   ,  Electronic Serials     ");
         criteria = null;

--- a/webcurator-webapp/src/main/java/org/webcurator/ui/target/controller/TargetInstanceResultHandler.java
+++ b/webcurator-webapp/src/main/java/org/webcurator/ui/target/controller/TargetInstanceResultHandler.java
@@ -365,12 +365,14 @@ public class TargetInstanceResultHandler extends TabHandler {
                 if (response != null && response.isCustomDepositFormRequired()) {
                     String customDepositFormHTMLContent = response.getHTMLForCustomDepositForm();
                     String customDepositFormURL = response.getUrlForCustomDepositForm();
+                    String customDepositFormSubmitURL = response.getUrlForCustomDepositFormSubmit();
 
                     // Will be needed to access the Rosetta interface
                     DigitalAssetStoreClient dasClient =(DigitalAssetStoreClient) getDASClient();
 
                     req.getSession().setAttribute("dasPort", Integer.toString(dasClient.getPort()));
                     req.getSession().setAttribute("dasHost", dasClient.getHost());
+                    req.getSession().setAttribute("customDepositFormSubmitURL",customDepositFormSubmitURL);
                     req.getSession().setAttribute("coreBaseUrl", getInTrayManager().getWctBaseUrl());
 
                     if (customDepositFormURL != null) {

--- a/webcurator-webapp/src/main/webapp/jsp/deposit-form-envelope.jsp
+++ b/webcurator-webapp/src/main/webapp/jsp/deposit-form-envelope.jsp
@@ -52,6 +52,7 @@ document.onkeypress = stopRKey;
 <input type="hidden" name="customDepositForm_targetDcType" value="<c:out value="${sessionTargetInstance.target.dublinCoreMetaData.type}"/>">
 <input id = "dasport" type="hidden" name="dasPort" value="<c:out value="${dasPort}"/>">
 <input id = "dashost" type="hidden" name="dasHost" value="<c:out value="${dasHost}"/>">
+<input id = "customDepositFormSubmitURL" type="hidden" name="customDepositFormSubmitURL" value="<c:out value="${customDepositFormSubmitURL}"/>">
 <input id = "coreBaseUrl" type="hidden" name="coreBaseUrl" value="<c:out value="${coreBaseUrl}"/>">
 
 <c:choose>


### PR DESCRIPTION
Add additional configuration for the custom deposit forms:
1. Made the URL configurable for submit the custom deposit form. The new configuration item is located in application.properties of Store:
```
# URLs that Users would use to submit the custom deposit form from browsers for
# each of the target types, separated by comma.
# A note on the format of this URL:
# - If the User's Browser and WCT Digital Asset Store are deployed in the same machine(usually for DEV or Test scenarios), the default value can be used.
# - If it is deployed behind a Fire Wall or Reverse Proxy, use the URL exposed from the Fire Wall or Reverse Proxy.
dpsArchive.htmlSerials.customDepositFormSubmitURLs=http://localhost:${server.port}
```
2. WebApp will fetch the customDepositFormSubmitURLs from Store and populate that into the custom deposit form for submitting the form to Store.