### PR TITLE
Integrate ReST API documentation in webcurator-docs

### DIFF
--- a/webcurator-docs/guides/api-introduction.rst
+++ b/webcurator-docs/guides/api-introduction.rst
@@ -1,0 +1,13 @@
+============
+Introduction
+============
+The seperation of client- and server-side has led to the development of a number of REST APIs for WCT. This documentation 
+describes some generic features of the WCT REST services and gives a description of the available APIs.
+
+Seperating the client- and server-side makes it possible to develop and change the frontend more easily and independently 
+from the server-side. Also this allows for the development of batch workflows.
+
+At the moment not all WCT information / functionality is covered by an API. The APIs are focussed on targets and target instances. In the 
+future more REST APIs will be added as needed. The impact of this is that some screens will still be 
+hardwired to WCT. Especially all configuration screens. The current assumption is that these will not change much and are also not needed
+in a remote batch workflow.

--- a/webcurator-docs/guides/api-principles.rst
+++ b/webcurator-docs/guides/api-principles.rst
@@ -1,0 +1,39 @@
+==========
+Principles
+==========
+
+Maturity
+========
+The WCT APIs are fully RESTful webservices as defined by the REST principals (https://restfulapi.net/). They also adhere to the Richardson maturity model level two. This level of maturity makes use of URIs and HTTP Methods, but does not implement HATEOAS (https://restfulapi.net/richardson-maturity-model/).  
+
+Versioning
+==========
+For the WCT APIs the version number of the API is part of the URI.
+
+If an API is deprecated and no longer supported the HTTP response code '501: Not Implemented' will be returned. The body of the 
+reposnse will be empty.
+
+Authentication
+==============
+To use an API the user must be authenticated. This is done by getting a session token from WCT via the authentication API. This
+token must be provided with each request to an API. This is done via the adding the authorization in the request header as follows:
+Authorization: Bearer <token>
+
+<token> is the string of characters (token) returned from the authentication API.
+
+Request
+=======
+All API requests make use of HTTPS, HTTP is not supported.
+ 
+The format of exchanged data is by default JSON. This applies to both requests and responses.
+
+Response
+========
+All API responses return a valid HTTP response code (https://en.wikipedia.org/wiki/List_of_HTTP_status_codes). Only if an API requests
+results in a correct and valid response '200 OK' is returned. In all other cases the appropriate HTTP error code is returned.
+
+The format of exchanged data is by default JSON. This applies to both requests and responses.
+ 
+Data format
+===========
+The format of exchanged data is by default JSON. This applies to both requests and responses. No other format is supported.

--- a/webcurator-docs/guides/api-release-notes.rst
+++ b/webcurator-docs/guides/api-release-notes.rst
@@ -1,0 +1,14 @@
+=============
+Release Notes
+=============
+This guide, designed for a Web Curator Tool developer,
+covers the release notes from version 1.0. Versions are in reverse
+chronological order, with the most recent version first. While the *API overview* is
+accurate for the current release, the *Release Notes* can give some idea of
+how things have changed since the last major release.
+
+Versions
+========
+1.0.0
+-----
+Released <month abbr> <year>, version 1.0.0 is the first release of the APIs for WCT.

--- a/webcurator-docs/guides/apis/api-agencies_GET.rst
+++ b/webcurator-docs/guides/apis/api-agencies_GET.rst
@@ -1,0 +1,64 @@
+Retrieve Agencies (GET)
+============================
+
+Returns a list of all the agencies.
+
+Version
+-------
+1.0.0
+
+Request
+-------
+``https://--WCT_base--/api/v1/agencies``
+
+Header
+------
+.. include:: /guides/apis/descriptions/desc-header-authentication.rst
+
+Body
+----
+.. include:: /guides/apis/descriptions/desc-request-body-empty.rst
+
+Response
+--------
+200: OK
+
+====== ==== ==========
+**Body**
+----------------------
+agencies List Optional
+======== ==== ========
+
+| **agencies**
+| This is a list of found agencies. It could be that no agencies are present. In that case an empty list is returned.
+ 
+The following information is returned per found agency:
+
+============ ====== ========
+**Body**
+----------------------------
+id           Number Required
+name         String Required
+address      String Required
+============ ====== ========
+
+Errors
+------
+If any error is raised no output is returned.
+
+=== ========================================================================================
+400 Bad Request, including reason why e.g. Unsupported or malformed sort spec <sortBy field>
+403 Not authorized, user is no longer logged in.
+405 Method not allowed, only GET is allowed.
+=== ========================================================================================
+
+Example
+-------
+.. code-block:: linux
+
+  curl \
+  --location --request GET 'http://kb006561i.clients.wpakb.kb.nl:8080/wct/api/v1/agencies' \
+  --header 'Content-Type: application/json' \
+  --header 'Authorization: Bearer <token>' \
+  --data ''
+ 

--- a/webcurator-docs/guides/apis/api-authentication_DELETE.rst
+++ b/webcurator-docs/guides/apis/api-authentication_DELETE.rst
@@ -1,0 +1,46 @@
+Delete token (DELETE)
+=====================
+Takes token as input and invalidates the specified token. This essentially menas the user logs out.
+
+If the token is unknown no error is given. This could happen if the token already has been invalidated due to inactivity. 
+
+Version
+-------
+1.0.0
+
+Request
+-------
+``https://--WCT_base--/auth/v1/token/{token}``
+
+.. include:: /guides/apis/descriptions/desc-token.rst
+
+Header
+------
+There are no specific header fields for this API.
+
+Body
+----
+.. include:: /guides/apis/descriptions/desc-request-body-empty.rst
+
+Response
+--------
+200: OK
+
+**Body**
+--------
+.. include:: /guides/apis/descriptions/desc-response-body-empty.rst
+
+Errors
+------
+If any error is raised then the token given is not invalidated.
+
+=== ==================================================================
+405 Method not allowed, only DELETE is allowed.
+=== ==================================================================
+
+Example
+-------
+.. code-block:: linux
+
+  curl \
+  --location --request DELETE 'http://localhost/wct/auth/v1/token/<token>'

--- a/webcurator-docs/guides/apis/api-authentication_POST.rst
+++ b/webcurator-docs/guides/apis/api-authentication_POST.rst
@@ -1,0 +1,67 @@
+Create token (POST)
+===================
+Takes username and password as input and returns a token that is valid until <x> minutes of inactivity. The time 
+of inactivity (<x>) is configurable in WCT.
+
+
+Each call to a WCT API (except for authentication for obvious reasons) must contain a valid token. The token must 
+be added to the HTTP header of each call:
+
+.. include:: /guides/apis/descriptions/desc-header-authentication.rst
+
+Version
+-------
+1.0.0
+
+Request
+-------
+``https://--WCT_base--/auth/v1/token``
+
+Header
+------
+There are no specific header fields for this API.
+
+Body
+----
+
+======== ====== ========
+**Body**
+------------------------
+username String Required
+password String Required
+======== ====== ========
+
+| **username**
+| Username of to be authenticated user in WCT.
+
+| **password**
+| Password of to be authenticated user in WCT.
+
+Response
+--------
+200: OK
+
+===== ====== ========
+**Body**
+---------------------
+token String Required
+===== ====== ========
+
+Errors
+------
+If any error is raised no token is returned.
+
+=== ==================================================================
+400 Bad Request, username and/or password are missing.
+403 Not authorized, given username and/or password are not valid.
+405 Method not allowed, only POST, DELETE are allowed.
+=== ==================================================================
+
+Example
+-------
+.. code-block:: linux
+
+  curl \
+  --location 'http://localhost/wct/auth/v1/token' \
+  --form 'username="<username>"' \
+  --form 'password="<password>"'

--- a/webcurator-docs/guides/apis/api-flags_GET.rst
+++ b/webcurator-docs/guides/apis/api-flags_GET.rst
@@ -1,0 +1,80 @@
+Retrieve Flags (GET)
+====================
+
+Returns all flags with a subset of the available information based upon given filter and sorting.
+
+Version
+-------
+1.0.0
+
+Request
+-------
+``https://--WCT_base--/api/v1/flags``
+
+Header
+------
+.. include:: /guides/apis/descriptions/desc-header-authentication.rst
+
+Body
+----
+.. include:: /guides/apis/descriptions/desc-query-method.rst
+
+====== ====== ========
+filter String Optional
+====== ====== ========
+
+| **filter**
+| Name of field upon which the result set must be filtered. Only filterable fields maybe given, others are ignored. Filterable fields are:
+
+* agency [exact match only]
+
+| With each filter field (key) a value must be given which is used to filter. The filter only shows those results that match or contains the given value in the given field. All given characters are used, there are no wild cards.
+
+Response
+--------
+200: OK
+
+========== ====== ========
+**Body**
+--------------------------
+filter     String Optional
+flags      List   Optional
+========== ====== ========
+
+| **flags**
+| This is a list of found flags. It could be that no flags are present. In that case an empty list is returned.
+ 
+The following information is returned per found flag:
+
+============ ====== ========
+**Body**
+----------------------------
+id           Number Required
+name         String Required
+rgb          String Required
+agency       String Required
+============ ====== ========
+
+.. include:: /guides/apis/descriptions/desc-flagId.rst
+
+Errors
+------
+If any error is raised no output is returned.
+
+=== ========================================================================================
+400 Bad Request, including reason why e.g. Unsupported or malformed sort spec <sortBy field>
+403 Not authorized, user is no longer logged in.
+405 Method not allowed, only GET is allowed.
+=== ========================================================================================
+
+Example
+-------
+.. code-block:: linux
+  curl \
+  --location --request GET 'http://kb006561i.clients.wpakb.kb.nl:8080/wct/api/v1/flags' \
+  --header 'Content-Type: application/json' \
+  --header 'Authorization: Bearer <token>' \
+  --data ''
+ 
+ 
+ 

--- a/webcurator-docs/guides/apis/api-group_DELETE.rst
+++ b/webcurator-docs/guides/apis/api-group_DELETE.rst
@@ -1,0 +1,43 @@
+Delete Group (DELETE)
+======================
+Deletes a specific group.
+
+Version
+-------
+1.0.0
+
+Request
+-------
+``https://--WCT_base--/api/v1/groups/{group-id}``
+
+Header
+------
+.. include:: /guides/apis/descriptions/desc-header-authentication.rst
+
+Body
+----
+.. include:: /guides/apis/descriptions/desc-request-body-empty.rst
+
+Response
+--------
+200: OK
+
+.. include:: /guides/apis/descriptions/desc-response-body-empty.rst
+
+Errors
+------
+If any error is raised no output is returned. Nor is the target removed.
+
+=== =======================================================================================
+400 Bad request, non-existing target-id has been given.
+400	Bad request, cannot delete as there are still target instances connected to the target.
+400	Bad request, cannot delete as target is not rejected or cancelled. 
+403 Not authorized, user is no longer logged in.
+405 Method not allowed, only POST, GET, PUT, DELETE are allowed.
+=== =======================================================================================
+
+Example
+-------
+.. code-block:: linux
+
+  TODO

--- a/webcurator-docs/guides/apis/api-group_GET.rst
+++ b/webcurator-docs/guides/apis/api-group_GET.rst
@@ -1,0 +1,65 @@
+Retrieve Group (GET)
+=====================
+Returns all information for a specific group.
+
+Version
+-------
+1.0.0
+
+Request
+-------
+``https://--WCT_base--/api/v1/groups/{group-id}``
+
+Also the following parts can be retrieved separately by adding the part name to the request query, e.g.
+``https://--WCT_base--/api/v1/groups/{group-id}/{part}``
+
++-------------+
+| **part**    |
++=============+
+| general     | 
++-------------+
+| members     |
++-------------+
+| memberOf    |
++-------------+
+| profile     |
++-------------+
+| schedule    |
++-------------+
+| annotations |
++-------------+
+| description |
++-------------+
+| access      |
++-------------+
+
+Header
+------
+.. include:: /guides/apis/descriptions/desc-header-authentication.rst
+
+Body
+----
+.. include:: /guides/apis/descriptions/desc-request-body-empty.rst
+
+Response
+--------
+200: OK
+
+.. include:: /guides/apis/descriptions/desc-group_response.rst
+
+Errors
+------
+If any error is raised no output is returned.
+
+=== ==========================================================================
+400 Bad request, non-existing target-id has been given.
+400 Bad request, non-existing part has been given.
+403 Not authorized, user is no longer logged in.
+405 Method not allowed, only POST, GET, PUT, DELETE are allowed.
+=== ==========================================================================
+
+Example
+-------
+.. code-block:: linux
+
+  TODO

--- a/webcurator-docs/guides/apis/api-group_states_GET.rst
+++ b/webcurator-docs/guides/apis/api-group_states_GET.rst
@@ -1,0 +1,51 @@
+Retrieve Group states (GET)
+============================
+
+Returns a list of all the states that a group can have, including the description of each specific state.
+
+Version
+-------
+1.0.0
+
+Request
+-------
+``https://--WCT_base--/api/v1/groups/states``
+
+Header
+------
+.. include:: /guides/apis/descriptions/desc-header-authentication.rst
+
+Body
+----
+.. include:: /guides/apis/descriptions/desc-request-body-empty.rst
+
+Response
+--------
+200: OK
+
+====== ==== ========
+**Body**
+--------------------
+states List Required
+====== ==== ========
+
+| **states**
+| Is a list of all the states that a target can have, including the description of each specific state.
+
+.. include:: /guides/apis/descriptions/desc-state_group.rst
+
+Errors
+------
+If any error is raised no output is returned.
+
+=== ========================================================================================
+400 Bad Request, including reason why e.g. Unsupported or malformed sort spec <sortBy field>
+403 Not authorized, user is no longer logged in.
+405 Method not allowed, only GET is allowed.
+=== ========================================================================================
+
+Example
+-------
+.. code-block:: linux
+
+  TODO

--- a/webcurator-docs/guides/apis/api-group_types_GET.rst
+++ b/webcurator-docs/guides/apis/api-group_types_GET.rst
@@ -1,0 +1,51 @@
+Retrieve Group types (GET)
+==========================
+
+Returns a list of all the types that a group can have.
+
+Version
+-------
+1.0.0
+
+Request
+-------
+``https://--WCT_base--/api/v1/groups/types``
+
+Header
+------
+.. include:: /guides/apis/descriptions/desc-header-authentication.rst
+
+Body
+----
+.. include:: /guides/apis/descriptions/desc-request-body-empty.rst
+
+Response
+--------
+200: OK
+
+===== ==== ========
+**Body**
+--------------------
+types List Required
+===== ==== ========
+
+| **types**
+| Is a list of all the types that a target can have, including the description of each specific type.
+
+.. include:: /guides/apis/descriptions/desc-type_group.rst
+
+Errors
+------
+If any error is raised no output is returned.
+
+=== ========================================================================================
+400 Bad Request, including reason why e.g. Unsupported or malformed sort spec <sortBy field>
+403 Not authorized, user is no longer logged in.
+405 Method not allowed, only GET is allowed.
+=== ========================================================================================
+
+Example
+-------
+.. code-block:: linux
+
+  TODO

--- a/webcurator-docs/guides/apis/api-groups_GET.rst
+++ b/webcurator-docs/guides/apis/api-groups_GET.rst
@@ -1,0 +1,111 @@
+Retrieve Groups (GET)
+=====================
+
+Returns all groups with a subset of the available information based upon given filter.
+
+Version
+-------
+1.0.0
+
+Request
+-------
+``https://--WCT_base--/api/v1/groups``
+
+Header
+------
+.. include:: /guides/apis/descriptions/desc-header-authentication.rst
+
+Body
+----
+.. include:: /guides/apis/descriptions/desc-query-method.rst
+
+====== ====== ========
+filter String Optional
+offset Number Optional
+limit  Number Optional
+====== ====== ========
+
+| **filter**
+| Name of field upon which the result set must be filtered. Only filterable fields maybe given, others are ignored. Filterable fields are:
+
+* groupId [exact match only]
+* name [contains text]
+* agency [exact match only]
+* userId [exact match only]
+* memberOf [contains text]
+* type [contains text]
+* nonDisplayOnly [Boolean]
+* state [List of integers, exact match only]
+
+| Multiple filter fields may be given, but each field only once. If a filter field is given multiple times this will result in an error.
+|
+| With each field (key) a value must be given which is used to filter. The filter only shows those results that match or contains the given value in the given field. All given characters are used, there are no wild cards.
+
+.. include:: /guides/apis/descriptions/desc-userId.rst
+
+.. include:: /guides/apis/descriptions/desc-groupType.rst
+
+.. include:: /guides/apis/descriptions/desc-request-offset.rst
+
+.. include:: /guides/apis/descriptions/desc-request-limit.rst
+
+.. include:: /guides/apis/descriptions/desc-type_group.rst
+
+.. include:: /guides/apis/descriptions/desc-state_group.rst
+
+Response
+--------
+200: OK
+
+========== ====== ========
+**Body**
+--------------------------
+filter     String Required
+offset     Number Required
+limit	   Number Required
+amount 	   Number Required
+groups     List   Optional
+========== ====== ========
+
+| **amount**
+| Number of total groups in the search result.  
+
+| **groups**
+| This is a list of found groups. It could be that no groups are present. In that case an empty list is returned.
+ 
+The following information is returned per found group:
+
+============ ====== ========
+**Body**
+----------------------------
+groupId      Number Required
+name         String Required
+type         String Required
+agency       String Required
+owner        String Required
+state        Number Required
+============ ====== ========
+
+.. include:: /guides/apis/descriptions/desc-type_group.rst
+
+.. include:: /guides/apis/descriptions/desc-owner.rst
+
+.. include:: /guides/apis/descriptions/desc-state_group.rst
+
+Errors
+------
+If any error is raised no output is returned.
+
+=== ========================================================================================
+400 Bad Request, including reason why e.g. Unsupported or malformed sort spec <sortBy field>
+403 Not authorized, user is no longer logged in.
+405 Method not allowed, only GET is allowed.
+=== ========================================================================================
+
+Example
+-------
+.. code-block:: linux
+
+  TODO
+ 
+ 

--- a/webcurator-docs/guides/apis/api-harvest-agents_GET.rst
+++ b/webcurator-docs/guides/apis/api-harvest-agents_GET.rst
@@ -1,0 +1,60 @@
+Retrieve Harvest Agents (GET)
+===============================
+
+Returns a list of all the harvest agents.
+
+Version
+-------
+1.0.0
+
+Request
+-------
+``https://--WCT_base--/api/v1/harvest-agents``
+
+Header
+------
+.. include:: /guides/apis/descriptions/desc-header-authentication.rst
+
+Body
+----
+.. include:: /guides/apis/descriptions/desc-request-body-empty.rst
+
+Response
+--------
+200: OK
+
+============== ==== ========
+**Body**
+----------------------------
+harvest-agents List Optional
+============== ==== ========
+
+| **harvest agents**
+| This is a list of found harvest agents.
+ 
+The following information is returned per found harvest agent:
+
+================ ====== ========
+**Body**
+--------------------------------
+harvestAgentName String Required
+MaxNumHarvests   Number Required
+NumHarvests      Number Required
+================ ====== ========
+
+Errors
+------
+If any error is raised no output is returned.
+
+=== ========================================================================================
+400 Bad Request, including reason why e.g. Unsupported or malformed sort spec <sortBy field>
+403 Not authorized, user is no longer logged in.
+405 Method not allowed, only GET is allowed.
+=== ========================================================================================
+
+Example
+-------
+.. code-block:: linux
+
+  <TODO>
+ 

--- a/webcurator-docs/guides/apis/api-harvest_authorisation_states_GET.rst
+++ b/webcurator-docs/guides/apis/api-harvest_authorisation_states_GET.rst
@@ -1,0 +1,54 @@
+Retrieve Harvest Authorisation states (GET)
+===========================================
+
+Returns a list of all the states that a harvest authorisation can have, including the description of each specific state.
+
+Version
+-------
+1.0.0
+
+Request
+-------
+``https://--WCT_base--/api/v1/harvest-authorisations/states``
+
+Header
+------
+.. include:: /guides/apis/descriptions/desc-header-authentication.rst
+
+Body
+----
+.. include:: /guides/apis/descriptions/desc-request-body-empty.rst
+
+Response
+--------
+200: OK
+
+====== ==== ========
+**Body**
+--------------------
+states List Required
+====== ==== ========
+
+| **states**
+| Is a list of all the states that a harvest authorisation can have, including the description of each specific state.
+
+.. include:: /guides/apis/descriptions/desc-state_harvest_authoristion.rst
+
+Errors
+------
+If any error is raised no output is returned.
+
+=== ========================================================================================
+400 Bad Request, including reason why e.g. Unsupported or malformed sort spec <sortBy field>
+403 Not authorized, user is no longer logged in.
+405 Method not allowed, only GET is allowed.
+=== ========================================================================================
+
+Example
+-------
+.. code-block:: linux
+
+  curl \
+  --location 'http://localhost/wct/api/v1/harvest-authorisations/states' \
+  --header 'Authorization: Bearer <token>'
+ 

--- a/webcurator-docs/guides/apis/api-harvest_authorisations_GET.rst
+++ b/webcurator-docs/guides/apis/api-harvest_authorisations_GET.rst
@@ -1,0 +1,122 @@
+Retrieve Harvest Authorisations (GET)
+====================================
+
+Returns all harvest authorisations with a subset of the available information based upon given filter and sorting.
+
+Version
+-------
+1.0.0
+
+Request
+-------
+``https://--WCT_base--/api/v1/harvest-authorisations``
+
+Header
+------
+.. include:: /guides/apis/descriptions/desc-header-authentication.rst
+
+Body
+----
+.. include:: /guides/apis/descriptions/desc-query-method.rst
+
+====== ====== ========
+filter String Optional
+sortBy String Optional
+offset Number Optional
+limit  Number Optional
+====== ====== ========
+
+| **filter**
+| Name of field upon which the result set must be filtered. Only filterable fields maybe given, others are ignored. Filterable fields are:
+
+* id [exact match only]
+* name [contains text]
+* authorisingAgent [contains text]
+* orderNo [exact match]
+* agency [exact match only]
+* showDisabled [boolean]
+* URLpattern [contains text]
+* permissionsFilereference [contains text]
+* permissionStates [List of integers, exact match only]
+
+| Multiple filter fields may be given, but each field only once. If a filter field is given multiple times this will result in an error.
+|
+| With each field (key) a value must be given which is used to filter. The filter only shows those results that match or contains the given value in the given field. All given characters are used, there are no wild cards.
+
+.. include:: /guides/apis/descriptions/desc-state_harvest_authoristion.rst
+
+| **sortBy**
+| Name of field upon which the result set must be sorted. The field name must be followed by an indication if the sorting must be ascending (asc) or descending (desc).
+
+| Only sortable fields maybe given, others are ignored. Sortable fields are:
+| * name (default)
+| * creationDate
+
+Only one sort field may be given as input. If multiple sort fields are given then this will result in an error. Example: sortBy=Name,asc
+
+.. include:: /guides/apis/descriptions/desc-request-offset.rst
+
+.. include:: /guides/apis/descriptions/desc-request-limit.rst
+
+Response
+--------
+200: OK
+
+===================== ====== ========
+**Body**
+-------------------------------------
+filter                String Required
+sortBy                String Optional
+offset                Number Required
+limit	              Number Required
+amount 	              Number Required
+harvestAuthorisations List   Optional
+===================== ====== ========
+
+| **amount**
+| Number of total groups in the search result.  
+
+| **harvestAuthorisations**
+| This is a list of found harvest authorisations. It could be that no harvest authorisations are present. In that case an empty list is returned.
+ 
+The following information is returned per found harvest authorisation:
+
+======================= ====== ========
+**Body**
+---------------------------------------
+id                      Number Required
+creationDate            Date   Required
+name                    String Required
+authorisingAgents       List   Optional
+orderNo                 String Optional
+permissionStates        List   Optional
+======================= ====== ========
+
+| **authorisingAgents**
+| List of of id's of authorising agents. The list of all agencies can be retrieved with API :doc: `api-agencies_GET.rst`.
+
+| **permissionStates**
+| List of permission states as given to the permissons in the harvest authorisation.
+
+.. include:: /guides/apis/descriptions/desc-state_harvest_authoristion.rst
+
+Errors
+------
+If any error is raised no output is returned.
+
+=== ========================================================================================
+400 Bad Request, including reason why e.g. Unsupported or malformed sort spec <sortBy field>
+403 Not authorized, user is no longer logged in.
+405 Method not allowed, only GET is allowed.
+=== ========================================================================================
+
+Example
+-------
+.. code-block:: linux
+
+  curl \
+  --location --request GET 'http://localhost/wct/api/v1/harvest-authorisations' \
+  --header 'Content-Type: application/json' \
+  --header 'Authorization: Bearer <token>' \
+  --data '{"filter": { "permissionStates": [2] }, "limit": 5, "sortBy": "creationDate,asc" }'
+ 

--- a/webcurator-docs/guides/apis/api-harvest_result_states_GET.rst
+++ b/webcurator-docs/guides/apis/api-harvest_result_states_GET.rst
@@ -1,0 +1,56 @@
+Retrieve Harvest Result States (GET)
+====================================
+
+Returns a list of all the states that a harvest result can have, including the description of each specific state.
+
+Version
+-------
+1.0.0
+
+Request
+-------
+``https://--WCT_base--/api/v1/target_instances/harvest-result-states``
+
+Header
+------
+.. include:: /guides/apis/descriptions/desc-header-authentication.rst
+
+Body
+----
+.. include:: /guides/apis/descriptions/desc-request-body-empty.rst
+
+Response
+--------
+200: OK
+
+====== ==== ========
+**Body**
+--------------------
+states List Required
+====== ==== ========
+
+| **states**
+| Is a list of all the states that a harvest result can have, including the description of each specific state.
+
+.. include:: /guides/apis/descriptions/desc-state_harvest_result.rst
+
+Errors
+------
+If any error is raised no output is returned.
+
+=== ========================================================================================
+400 Bad Request, including reason why e.g. Unsupported or malformed sort spec <sortBy field>
+403 Not authorized, user is no longer logged in.
+405 Method not allowed, only GET is allowed.
+=== ========================================================================================
+
+Example
+-------
+.. code-block:: linux
+
+  curl \
+  --location --request GET 'http://kb006561i.clients.wpakb.kb.nl:8080/wct/api/v1/harvest-result-states' \
+  --header 'Content-Type: application/json' \
+  --header 'Authorization: Bearer <token>' \
+  --data ''
+ 

--- a/webcurator-docs/guides/apis/api-overview.rst
+++ b/webcurator-docs/guides/apis/api-overview.rst
@@ -1,0 +1,102 @@
+============
+API Overview
+============
+In general the version number in the api call is the letter 'v' followed by the latest major version number. E.g. 'v1'. It is also possible 
+to use the string 'latest' to call upon the latest version of the api. 
+
+If an api is deprecated and no longer supported then the error 404 'Not Found – the requested resource does not exist' is returned. 
+
+Agency
+======
+.. toctree::
+   :maxdepth: 1
+
+   api-agencies_GET
+
+Authentication
+==============
+.. toctree::
+   :maxdepth: 1
+
+   api-authentication_POST
+   api-authentication_DELETE
+
+Flag
+====
+.. toctree::
+   :maxdepth: 1
+   
+   api-flags_GET.rst
+
+Group
+=====
+.. toctree::
+   :maxdepth: 1
+   
+   api-groups_GET.rst
+   api-group_GET.rst
+   api-group_DELETE.rst
+   api-group_states_GET.rst
+   api-group_types_GET.rst
+
+Harvest Agents
+==============
+.. toctree::
+   :maxdepth: 1
+   
+   api-harvest-agents_GET.rst
+   
+Harvest Authorisations
+======================
+.. toctree::
+   :maxdepth: 1
+   
+   api-harvest_authorisations_GET.rst
+   api-harvest_authorisation_states_GET.rst
+   
+Profile
+=======
+.. toctree::
+   :maxdepth: 1
+   
+   api-profiles_GET.rst
+   api-profile_states_GET.rst
+   
+Targets
+=======
+.. toctree::
+   :maxdepth: 1
+
+   api-targets_GET
+   api-target_POST
+   api-target_GET
+   api-target_PUT
+   api-target_DELETE
+   api-target_states_GET
+   api-target_scheduleTypes_GET
+   
+Target Instances
+================
+.. toctree::
+   :maxdepth: 1
+
+   api-target_instances_GET
+   api-target_instance_GET
+   api-target_instance_PUT
+   api-target_instance_PUT_abort
+   api-target_instance_PUT_patch-harvest
+   api-target_instance_PUT_pause
+   api-target_instance_PUT_resume
+   api-target_instance_PUT_start
+   api-target_instance_PUT_stop
+   api-target_instance_DELETE
+   api-target_instance_states_GET
+   api-harvest_result_states_GET
+
+   
+User
+====
+.. toctree::
+   :maxdepth: 1
+   
+   api-users_GET.rst

--- a/webcurator-docs/guides/apis/api-profile_states_GET.rst
+++ b/webcurator-docs/guides/apis/api-profile_states_GET.rst
@@ -1,0 +1,56 @@
+Retrieve Profile states (GET)
+===========================================
+
+Returns a list of all the states that a profile can have, including the description of each specific state.
+
+Version
+-------
+1.0.0
+
+Request
+-------
+``https://--WCT_base--/api/v1/profiles/states``
+
+Header
+------
+.. include:: /guides/apis/descriptions/desc-header-authentication.rst
+
+Body
+----
+.. include:: /guides/apis/descriptions/desc-request-body-empty.rst
+
+Response
+--------
+200: OK
+
+====== ==== ========
+**Body**
+--------------------
+states List Required
+====== ==== ========
+
+| **states**
+| Is a list of all the states that a profile can have, including the description of each specific state.
+
+.. include:: /guides/apis/descriptions/desc-state_profile.rst
+
+Errors
+------
+If any error is raised no output is returned.
+
+=== ========================================================================================
+400 Bad Request, including reason why e.g. Unsupported or malformed sort spec <sortBy field>
+403 Not authorized, user is no longer logged in.
+405 Method not allowed, only GET is allowed.
+=== ========================================================================================
+
+Example
+-------
+.. code-block:: linux
+
+  curl \
+  --location --request GET 'http://kb006561i.clients.wpakb.kb.nl:8080/wct/api/v1/profiles/states' \
+  --header 'Content-Type: application/json' \
+  --header 'Authorization: Bearer <token>' \
+  --data ''
+ 

--- a/webcurator-docs/guides/apis/api-profiles_GET.rst
+++ b/webcurator-docs/guides/apis/api-profiles_GET.rst
@@ -1,0 +1,105 @@
+Retrieve Profiles (GET)
+=======================
+
+Returns all profiles with a subset of the available information based upon given filter.
+
+Version
+-------
+1.0.0
+
+Request
+-------
+``https://--WCT_base--/api/v1/profiles``
+
+Header
+------
+.. include:: /guides/apis/descriptions/desc-header-authentication.rst
+
+Body
+----
+.. include:: /guides/apis/descriptions/desc-query-method.rst
+
+====== ====== ========
+filter String Optional
+====== ====== ========
+
+| **filter**
+| Name of field upon which the result set must be filtered. Only filterable fields maybe given, others are ignored. Filterable fields are:
+
+* showOnlyActive [Boolean] (default: true)
+* agency [contains text]
+* type [contains text]
+		
+| Multiple filter fields may be given, but each field only once. If a filter field is given multiple times this will result in an error.
+|
+| With each field (key) a value must be given which is used to filter. The filter only shows those results that match or contains the given value in the given field. All given characters are used, there are no wild cards.
+
+| **showOnlyActive**
+| When this field has the value 'true' only profiles with a state of 1 [active] are shown. When the value of this field is 'false' all profiles are shown irrespective of the state value. 
+
+| **type**
+| There are only two types:
+
+* HERITRIX1
+* HERITRIX3 (default)
+
+Response
+--------
+200: OK
+
+========== ====== ========
+**Body**
+--------------------------
+filter     String Required
+profiles   List   Optional
+========== ====== ========
+
+| **profiles**
+| This is a list of found profiles. It could be that no profiles are present. In that case an empty list is returned.
+ 
+The following information is returned per found profile:
+
+============ ======= ========
+**Body**
+-----------------------------
+id           Number  Required
+name         String  Required
+default      Boolean Required
+description  String  Optional
+type         String  Required
+state        Number  Required
+agency       String  Required
+============ ======= ========
+
+| **default**
+| Only one active profile per type can be the default profile. In other words where the field 'default' has the value 'true'. For all other states this can occur multiple times.
+
+| **type**
+| There are only two types:
+
+* HERITRIX1
+* HERITRIX3 (default)
+
+.. include:: /guides/apis/descriptions/desc-state_profile.rst
+
+Errors
+------
+If any error is raised no output is returned.
+
+=== ========================================================================================
+400 Bad Request, including reason why e.g. Unsupported or malformed sort spec <sortBy field>
+403 Not authorized, user is no longer logged in.
+405 Method not allowed, only GET is allowed.
+=== ========================================================================================
+
+Example
+-------
+.. code-block:: linux
+
+    curl \
+  --location 'http://localhost/wct/api/v1/profiles' \
+  --header 'Authorization: Bearer <token>' \
+  --data '{"filter": { "showOnlyActive": "false" } }'
+ 
+ 
+ 

--- a/webcurator-docs/guides/apis/api-target_DELETE.rst
+++ b/webcurator-docs/guides/apis/api-target_DELETE.rst
@@ -1,0 +1,49 @@
+Delete Target (DELETE)
+======================
+Deletes a specific target. This is only possible if there are no attached target instances. Also the status of the target must be 'Rejected' or 'Cancelled'. After a delete the target will have been completly removed from the WCT database.
+
+If the target must be set to 'Rejected' or 'Cancelled' then the API :doc:`/guides/apis/api-target_PUT` must be used.
+
+Version
+-------
+1.0.0
+
+Request
+-------
+``https://--WCT_base--/api/v1/targets/{target-id}``
+
+Header
+------
+.. include:: /guides/apis/descriptions/desc-header-authentication.rst
+
+Body
+----
+.. include:: /guides/apis/descriptions/desc-request-body-empty.rst
+
+Response
+--------
+200: OK
+
+.. include:: /guides/apis/descriptions/desc-response-body-empty.rst
+
+Errors
+------
+If any error is raised no output is returned. Nor is the target removed.
+
+=== =======================================================================================
+400 Bad request, non-existing target-id has been given.
+400	Bad request, cannot delete as there are still target instances connected to the target.
+400	Bad request, cannot delete as target is not rejected or cancelled. 
+403 Not authorized, user is no longer logged in.
+405 Method not allowed, only POST, GET, PUT, DELETE are allowed.
+=== =======================================================================================
+
+Example
+-------
+.. code-block:: linux
+
+  curl \
+  --location --request DELETE 'http://localhost/wct/api/v1/targets/{target-id}' \
+  --header 'Authorization: Bearer <token>' \
+  --header 'Content-Type: application/json' \
+  --data ''

--- a/webcurator-docs/guides/apis/api-target_GET.rst
+++ b/webcurator-docs/guides/apis/api-target_GET.rst
@@ -1,0 +1,73 @@
+Retrieve Target (GET)
+=====================
+Returns all information for a specific target.
+
+Version
+-------
+1.0.0
+
+Request
+-------
+``https://--WCT_base--/api/v1/targets/{target-id}``
+
+Also the following parts can be retrieved separately by adding the part name to the request query, e.g.
+``https://--WCT_base--/api/v1/target/{target-id}/{part}``
+
++-------------+
+| **part**    |
++=============+
+| general     | 
++-------------+
+| seeds       |
++-------------+
+| profile     |
++-------------+
+| schedule    |
++-------------+
+| annotations |
++-------------+
+| description |
++-------------+
+| groups      |
++-------------+
+| access      |
++-------------+
+
+Header
+------
+.. include:: /guides/apis/descriptions/desc-header-authentication.rst
+
+Body
+----
+.. include:: /guides/apis/descriptions/desc-request-body-empty.rst
+
+Response
+--------
+200: OK
+
+.. include:: /guides/apis/descriptions/desc-target_response.rst
+
+Errors
+------
+If any error is raised no output is returned.
+
+=== ==========================================================================
+400 Bad request, non-existing target-id has been given.
+400 Bad request, non-existing part has been given.
+403 Not authorized, user is no longer logged in.
+405 Method not allowed, only POST, GET, PUT, DELETE are allowed.
+=== ==========================================================================
+
+Example
+-------
+.. code-block:: linux
+
+  curl \
+  --location 'http://localhost/wct/api/v1/targets/<target-id>' \
+  --header 'Authorization: Bearer <token>'
+  
+.. code-block:: linux
+
+  curl \
+  --location 'http://localhost/wct/api/v1/targets/<target-id>/general' \
+  --header 'Authorization: Bearer <token>'

--- a/webcurator-docs/guides/apis/api-target_POST.rst
+++ b/webcurator-docs/guides/apis/api-target_POST.rst
@@ -1,0 +1,139 @@
+Create Target (POST)
+====================
+Create a target.
+
+Version
+-------
+1.0.0
+
+Request
+-------
+``https://--WCT_base--/api/v1/targets``
+
+Header
+------
+.. include:: /guides/apis/descriptions/desc-header-authentication.rst
+
+Body
+----
+.. include:: /guides/apis/descriptions/desc-target_request.rst
+
+Response
+--------
+201: OK
+
+.. include:: /guides/apis/descriptions/desc-response-body-empty.rst
+
+The HTTP Header Location contains the URL to retrieve (GET) the inserted target
+as described in :doc:`/guides/apis/api-target_GET`.
+
+Errors
+------
+If any error is raised no output is returned. Nor is the target created.
+
+=== =======================================================================================
+400	Bad request, required value <element> has not been given.
+403 Not authorized, user is no longer logged in.
+405 Method not allowed, only POST, GET, PUT, DELETE are allowed.
+=== =======================================================================================
+
+Example
+-------
+.. code-block:: linux
+
+  curl \
+  --location 'http://localhost/wct/api/v1/targets/<target-id>' \
+  --header 'Authorization: Bearer <token>' \ 
+  --header 'Content-Type: application/json' \
+  --data-raw '{"general": { \
+    "owner": "demo", \
+    "state": 2, \
+    "name" : "TEST - TARGET 2023-07-06T09:43:09.816Z" \
+    } \
+    }'
+
+.. code-block:: linux
+
+  curl --location 'http://localhost/wct/api/v1/targets' \
+  --header 'Authorization: Bearer <token>' \
+  --header 'Content-Type: application/json' \
+  --data-raw '{
+    "general": {
+        "owner": "demo",
+        "state": 5,
+        "name": "TEST - TARGET 2023-07-12T11:35:21.376Z - IJsselbiënale",
+        "description": "info@ijsselbiennale.nl"
+    },
+
+    "profile": {
+        "id": "1",
+        "imported": false,
+        "harvesterType": "HERITIRX3",
+        "name": "Default - KB",
+        "overrides": [
+            {
+                "id": "ignoreRobots",
+                "value": true,
+                "enabled": true
+            }
+        ]
+    },
+
+    "groups": [{"id": 70, "name": "testgroep"}],
+
+    "description": {
+        "description": "Test target",
+        "type": "01 - Algemeen"
+    },
+
+    "access": {
+        "displayTarget": true,
+        "accessZone": "0",
+        "accessZoneText": "Public"
+    },
+
+    "annotations": { 
+        "selection": {
+            "date": "2023-05-17T13:37:13.919+00:00",
+            "note": null,
+            "type": "Producer type"
+        },
+        "annotations": [
+            {
+            "date": "2023-05-17T13:37:13.919+00:00",
+            "note": "Testannotatie no.1",
+            "user": "demo",
+            "alert": false
+            },
+            {
+            "date": "2023-06-17T13:37:13.919+00:00",
+            "note": "Testannotatie no.2",
+            "user": "demo",
+            "alert": true
+            }
+        ],
+        "evalutionNote": null,
+        "harvestType": "Subject"
+    },
+
+    "seeds": [
+        {
+            "seed": "https://dummyurl.org",
+            "primary": true,
+            "authorisations": [98304]
+        }
+    ],
+    
+    "schedule": {
+        "harvestOptimization": false,
+        "schedules": [
+            {
+                "cron": "00 23 25 7,8,9 ? *",
+                "startDate": "2019-12-03T15:55:22.000+00:00",
+                "type": -3,
+                "nextExecutionDate": "2024-12-03T15:55:22.000+00:00",
+                "owner": "demo"
+            }
+        ]
+    }
+  }'

--- a/webcurator-docs/guides/apis/api-target_PUT.rst
+++ b/webcurator-docs/guides/apis/api-target_PUT.rst
@@ -1,0 +1,78 @@
+Update Target (PUT)
+===================
+Update a specific target or part therof.
+
+Version
+-------
+1.0.0
+
+Request
+-------
+``https://--WCT_base--/api/v1/targets/{target-id}``
+
+Also the following parts can be updated separately by adding the part name to the request query, e.g.
+``https://--WCT_base--/api/v1/target/{target-id}/{part}``
+
+Each part must contain at least one field that needs updating. Only the fields given are updated, fields not given, but present in the database, remain unchanged.
+
+Fields of mutable lists (seeds, schedule.schedules, annotations.annotations, groups) can not be updated individually: if a list is present in the input, the corresponding list attribute of the target will be overwritten with the new list. Fields of profile.overrides, which is a fixed list, can be updated individually.
+
++-------------+
+| **part**    |
++=============+
+| general     | 
++-------------+
+| seeds       |
++-------------+
+| profile     |
++-------------+
+| schedule    |
++-------------+
+| annotations |
++-------------+
+| description |
++-------------+
+| groups      |
++-------------+
+| access      |
++-------------+
+
+Header
+------
+.. include:: /guides/apis/descriptions/desc-header-authentication.rst
+
+Body
+----
+.. include:: /guides/apis/descriptions/desc-target_request.rst
+
+Response
+--------
+200: OK
+
+.. include:: /guides/apis/descriptions/desc-response-body-empty.rst
+
+Errors
+------
+If any error is raised no output is returned. Nor is the target created.
+
+=== =======================================================================================
+400	Bad request, required value <element> has not been given.
+403 Not authorized, user is no longer logged in.
+405 Method not allowed, only POST, GET, PUT, DELETE are allowed.
+=== =======================================================================================
+
+Example
+-------
+.. code-block:: linux
+
+  curl \
+  --location 'http://localhost/wct/api/v1/targets/<target-id>' 
+  --header 'Authorization: Bearer <token>'  
+  --header 'Content-Type: application/json' 
+  --data-raw '{ 
+    "general": { 
+      "owner": "demo", 
+      "state": 2, 
+      "name" : "TEST - TARGET 2023-07-06T09:43:09.816Z" 
+    } 
+  }'

--- a/webcurator-docs/guides/apis/api-target_instance_DELETE.rst
+++ b/webcurator-docs/guides/apis/api-target_instance_DELETE.rst
@@ -1,0 +1,42 @@
+Delete Target instance (DELETE)
+===============================
+Deletes a specific target instance. This is only possible if the status of the target instance is 'Scheduled' or 'Queued'. After a delete the target instance will have been completly removed from the WCT database.
+
+Version
+-------
+1.0.0
+
+Request
+-------
+``https://--WCT_base--/api/v1/target_instances/{target_instance-id}``
+
+Header
+------
+.. include:: /guides/apis/descriptions/desc-header-authentication.rst
+
+Body
+----
+.. include:: /guides/apis/descriptions/desc-request-body-empty.rst
+
+Response
+--------
+200: OK
+
+.. include:: /guides/apis/descriptions/desc-response-body-empty.rst
+
+Errors
+------
+If any error is raised no output is returned. Nor is the target removed.
+
+=== =======================================================================================
+400 Bad request, non-existing target_instnace-id has been given.
+400	Bad request, cannot delete as target instance is not scheduled, aborted or rejected. 
+403 Not authorized, user is no longer logged in.
+405 Method not allowed, only GET, PUT, DELETE are allowed.
+=== =======================================================================================
+
+Example
+-------
+.. code-block:: linux
+
+  <TODO>

--- a/webcurator-docs/guides/apis/api-target_instance_GET.rst
+++ b/webcurator-docs/guides/apis/api-target_instance_GET.rst
@@ -1,0 +1,64 @@
+Retrieve Target Instance (GET)
+==============================
+Returns all information for a specific target instance.
+
+Version
+-------
+1.0.0
+
+Request
+-------
+``https://--WCT_base--/api/v1/target-instances/{target-instance-id}``
+
+Also the following parts can be retrieved separately by adding the part name to the request query, e.g.
+``https://--WCT_base--/api/v1/target_instances/{target-instance-id}/{part}``
+
++-----------------+
+| **part**        |
++=================+
+| general         | 
++-----------------+
+| profile         |
++-----------------+
+| harvest-state   |
++-----------------+
+| logs            |
++-----------------+
+| harvest-results |
++-----------------+
+| annotations     |
++-----------------+
+| display         |
++-----------------+
+
+Header
+------
+.. include:: /guides/apis/descriptions/desc-header-authentication.rst
+
+Body
+----
+.. include:: /guides/apis/descriptions/desc-request-body-empty.rst
+
+Response
+--------
+200: OK
+
+.. include:: /guides/apis/descriptions/desc-target_instance_response.rst
+
+Errors
+------
+If any error is raised no output is returned.
+
+=== ========================================================================================
+400 Bad Request, including reason why e.g. Unsupported or malformed sort spec <sortBy field>
+403 Not authorized, user is no longer logged in.
+405 Method not allowed, only GET is allowed.
+=== ========================================================================================
+
+Example
+-------
+.. code-block:: linux
+
+  curl \
+  --location 'http://localhost/wct/api/v1/target-instances/<target-instance-id>' \
+  --header 'Authorization: Bearer <token>'

--- a/webcurator-docs/guides/apis/api-target_instance_PUT.rst
+++ b/webcurator-docs/guides/apis/api-target_instance_PUT.rst
@@ -1,0 +1,50 @@
+Update Target Instance (PUT)
+===============================
+Update a specific target instance or part therof.
+
+Note that not all fields are updatable. If non-updatable fields are given in the request this will lead to an error.
+
+Version
+-------
+1.0.0
+
+Request
+-------
+``https://--WCT_base--/api/v1/target_instances/{target_instance-id}``
+
+Also the following parts can be updated separately by adding the part name to the request query, e.g.
+``https://--WCT_base--/api/v1/target_instances/{target_instance-id}/{part}``
+
+Each part must contain at least one field that needs updating. Only the fields given are updated, fields not given, but present in the database, remain unchanged.
+
+Fields of mutable lists (annotations.annotations) can not be updated individually: if a list is present in the input, the corresponding list attribute of the target will be overwritten with the new list. Fields of profile.overrides, which is a fixed list, can be updated individually.
+
+Header
+------
+.. include:: /guides/apis/descriptions/desc-header-authentication.rst
+
+Body
+----
+.. include:: /guides/apis/descriptions/desc-target_instance_request.rst
+
+Response
+--------
+200: OK
+
+.. include:: /guides/apis/descriptions/desc-response-body-empty.rst
+
+Errors
+------
+If any error is raised no output is returned.
+
+=== ========================================================================================
+400 Bad Request, including reason why e.g. Unsupported or malformed sort spec <sortBy field>
+403 Not authorized, user is no longer logged in.
+405 Method not allowed, only GET, PUT, DELETE is allowed.
+=== ========================================================================================
+
+Example
+-------
+.. code-block:: linux
+
+  <TODO>

--- a/webcurator-docs/guides/apis/api-target_instance_PUT_abort.rst
+++ b/webcurator-docs/guides/apis/api-target_instance_PUT_abort.rst
@@ -1,0 +1,41 @@
+Abort Target Instance (PUT)
+===========================
+Aborts a running target instance.
+
+Version
+-------
+1.0.0
+
+Request
+-------
+``https://--WCT_base--/api/v1/target-instances/{target-instance-id}/abort``
+
+Header
+------
+.. include:: /guides/apis/descriptions/desc-header-authentication.rst
+
+Body
+----
+.. include:: /guides/apis/descriptions/desc-request-body-empty.rst
+
+Response
+--------
+200: OK
+
+Errors
+------
+If any error is raised no output is returned.
+
+=== ========================================================================================
+400 Bad Request, including reason why e.g. Not a running target instance.
+403 Not authorized, user is no longer logged in.
+405 Method not allowed, only GET is allowed.
+=== ========================================================================================
+
+Example
+-------
+.. code-block:: linux
+
+  curl \
+  --location 'http://localhost/wct/api/v1/target-instances/<target-instance-id>/abort' \
+  --header 'Authorization: Bearer <token>'

--- a/webcurator-docs/guides/apis/api-target_instance_PUT_patch-harvest.rst
+++ b/webcurator-docs/guides/apis/api-target_instance_PUT_patch-harvest.rst
@@ -1,0 +1,56 @@
+Patch Target Instance Harvest(PUT)
+==================================
+Start harvest of a target instance immediately and patch a specific harvest with the results.
+
+Version
+-------
+1.0.0
+
+Request
+-------
+``https://--WCT_base--/api/v1/target-instances/{target-instance-id}/patch-harvest``
+
+Header
+------
+.. include:: /guides/apis/descriptions/desc-header-authentication.rst
+
+Body
+----
+
+================ ====== ========
+**Body**
+--------------------------------
+harvestAgentName String Required
+HarvestResultId	 Number Required
+================ ====== ========
+
+| **harvestAgentName**
+| Name of valid harvest agent as defined in application.properties.
+
+The list of possible harvest agent name values can be retrieved with API :doc:`/guides/apis/api-harvest-agents_GET`.
+
+| **HarvestResultId**
+| Id of specific harvest result that needs to be patched with the harvest results.
+
+Response
+--------
+200: OK
+
+Errors
+------
+If any error is raised no output is returned.
+
+=== ========================================================================================
+400 Bad Request, including reason why e.g. Not a stopped target instance.
+403 Not authorized, user is no longer logged in.
+405 Method not allowed, only GET is allowed.
+=== ========================================================================================
+
+Example
+-------
+.. code-block:: linux
+
+  <TODO>
+  curl \
+  --location 'http://localhost/wct/api/v1/target-instances/<target-instance-id>/harvest_now' \
+  --header 'Authorization: Bearer <token>'

--- a/webcurator-docs/guides/apis/api-target_instance_PUT_pause.rst
+++ b/webcurator-docs/guides/apis/api-target_instance_PUT_pause.rst
@@ -1,0 +1,41 @@
+Pause Target Instance (PUT)
+===========================
+Pauses a running target instance.
+
+Version
+-------
+1.0.0
+
+Request
+-------
+``https://--WCT_base--/api/v1/target-instances/{target-instance-id}/pause``
+
+Header
+------
+.. include:: /guides/apis/descriptions/desc-header-authentication.rst
+
+Body
+----
+.. include:: /guides/apis/descriptions/desc-request-body-empty.rst
+
+Response
+--------
+200: OK
+
+Errors
+------
+If any error is raised no output is returned.
+
+=== ========================================================================================
+400 Bad Request, including reason why e.g. Not a running target instance.
+403 Not authorized, user is no longer logged in.
+405 Method not allowed, only GET is allowed.
+=== ========================================================================================
+
+Example
+-------
+.. code-block:: linux
+
+  curl \
+  --location 'http://localhost/wct/api/v1/target-instances/<target-instance-id>/pause' \
+  --header 'Authorization: Bearer <token>'

--- a/webcurator-docs/guides/apis/api-target_instance_PUT_resume.rst
+++ b/webcurator-docs/guides/apis/api-target_instance_PUT_resume.rst
@@ -1,0 +1,42 @@
+Resume Target Instance (PUT)
+===========================
+Resume harvest of a target instance immediately.
+
+Version
+-------
+1.0.0
+
+Request
+-------
+``https://--WCT_base--/api/v1/target-instances/{target-instance-id}/resume``
+
+Header
+------
+.. include:: /guides/apis/descriptions/desc-header-authentication.rst
+
+Body
+----
+.. include:: /guides/apis/descriptions/desc-request-body-empty.rst
+
+Response
+--------
+200: OK
+
+Errors
+------
+If any error is raised no output is returned.
+
+=== ========================================================================================
+400 Bad Request, including reason why e.g. Not a stopped target instance.
+403 Not authorized, user is no longer logged in.
+405 Method not allowed, only GET is allowed.
+=== ========================================================================================
+
+Example
+-------
+.. code-block:: linux
+
+  <TODO>
+  curl \
+  --location 'http://localhost/wct/api/v1/target-instances/<target-instance-id>/resume' \
+  --header 'Authorization: Bearer <token>'

--- a/webcurator-docs/guides/apis/api-target_instance_PUT_start.rst
+++ b/webcurator-docs/guides/apis/api-target_instance_PUT_start.rst
@@ -1,0 +1,52 @@
+Start Target Instance (PUT)
+===========================
+Start harvest of a target instance immediately.
+
+Version
+-------
+1.0.0
+
+Request
+-------
+``https://--WCT_base--/api/v1/target-instances/{target-instance-id}/start``
+
+Header
+------
+.. include:: /guides/apis/descriptions/desc-header-authentication.rst
+
+Body
+----
+
+================ ====== ========
+**Body**
+--------------------------------
+harvestAgentName String Required
+================ ====== ========
+
+| **harvestAgentName**
+| Name of valid harvest agent as defined in application.properties.
+
+The list of possible harvest agent name values can be retrieved with API :doc:`/guides/apis/api-harvest-agents_GET`.
+
+Response
+--------
+200: OK
+
+Errors
+------
+If any error is raised no output is returned.
+
+=== ========================================================================================
+400 Bad Request, including reason why e.g. Not a stopped target instance.
+403 Not authorized, user is no longer logged in.
+405 Method not allowed, only GET is allowed.
+=== ========================================================================================
+
+Example
+-------
+.. code-block:: linux
+
+  <TODO>
+  curl \
+  --location 'http://localhost/wct/api/v1/target-instances/<target-instance-id>/harvest_now' \
+  --header 'Authorization: Bearer <token>'

--- a/webcurator-docs/guides/apis/api-target_instance_PUT_stop.rst
+++ b/webcurator-docs/guides/apis/api-target_instance_PUT_stop.rst
@@ -1,0 +1,41 @@
+Stop Target Instance (PUT)
+==========================
+Stops a running target instance.
+
+Version
+-------
+1.0.0
+
+Request
+-------
+``https://--WCT_base--/api/v1/target-instances/{target-instance-id}/stop``
+
+Header
+------
+.. include:: /guides/apis/descriptions/desc-header-authentication.rst
+
+Body
+----
+.. include:: /guides/apis/descriptions/desc-request-body-empty.rst
+
+Response
+--------
+200: OK
+
+Errors
+------
+If any error is raised no output is returned.
+
+=== ========================================================================================
+400 Bad Request, including reason why e.g. Not a running target instance.
+403 Not authorized, user is no longer logged in.
+405 Method not allowed, only GET is allowed.
+=== ========================================================================================
+
+Example
+-------
+.. code-block:: linux
+
+  curl \
+  --location 'http://localhost/wct/api/v1/target-instances/<target-instance-id>/stop' \
+  --header 'Authorization: Bearer <token>'

--- a/webcurator-docs/guides/apis/api-target_instance_states_GET.rst
+++ b/webcurator-docs/guides/apis/api-target_instance_states_GET.rst
@@ -1,0 +1,55 @@
+Retrieve Target Instance States (GET)
+=====================================
+
+Returns a list of all the states that a target instance can have, including the description of each specific state.
+
+Version
+-------
+1.0.0
+
+Request
+-------
+``https://--WCT_base--/api/v1/target_instances/states``
+
+Header
+------
+.. include:: /guides/apis/descriptions/desc-header-authentication.rst
+
+Body
+----
+.. include:: /guides/apis/descriptions/desc-request-body-empty.rst
+
+Response
+--------
+200: OK
+
+====== ==== ========
+**Body**
+--------------------
+states List Required
+====== ==== ========
+
+| **states**
+| Is a list of all the states that a target can have, including the description of each specific state.
+
+.. include:: /guides/apis/descriptions/desc-state_target_instance.rst
+
+Errors
+------
+If any error is raised no output is returned.
+
+=== ========================================================================================
+400 Bad Request, including reason why e.g. Unsupported or malformed sort spec <sortBy field>
+403 Not authorized, user is no longer logged in.
+405 Method not allowed, only GET is allowed.
+=== ========================================================================================
+
+Example
+-------
+.. code-block:: linux
+
+  curl \
+  --location 'http://localhost/wct/api/v1/target-instances/states' \
+  --header 'Authorization: Bearer <token>' \
+  --data ''
+ 

--- a/webcurator-docs/guides/apis/api-target_instances_GET.rst
+++ b/webcurator-docs/guides/apis/api-target_instances_GET.rst
@@ -1,0 +1,142 @@
+Retrieve Target Instances (GET)
+===============================
+Returns all target instances with a subset of the available information based upon given filter and sorting.
+
+Version
+-------
+1.0.0
+
+Request
+-------
+``https://--WCT_base--/api/v1/target-instances``
+
+Header
+------
+.. include:: /guides/apis/descriptions/desc-header-authentication.rst
+
+Body
+----
+.. include:: /guides/apis/descriptions/desc-query-method.rst
+
+====== ====== ========
+filter String Optional
+sortBy String Optional
+offset Number Optional
+limit  Number Optional
+====== ====== ========
+
+| **filter**
+| Name of field upon which the result set must be filtered. Only filterable fields maybe given, others are ignored. Filterable fields are:
+
+* targetId (exact match only)
+* targetInstanceId [exact match only]
+* from [harvestDate is larger or equal to this date]
+* to [harvestDate is smaller or equal to this date]
+* agency [exact match only]
+* userId [exact match only]
+* name [contains text]
+* flagId [exact match only]
+* nonDisplayOnly [Boolean]
+* state [List of integers, exact match only]
+* qaRecommendation [List of strings, exact match only]
+
+| Multiple filter fields may be given, but each field only once. If a filter field is given multiple times this will result in an error.
+|
+| With each field (key) a value must be given which is used to filter. The filter only shows those results that match or contains the given value in the given field. All given characters are used, there are no wild cards.
+
+.. include:: /guides/apis/descriptions/desc-userId.rst
+
+.. include:: /guides/apis/descriptions/desc-flagId.rst
+
+.. include:: /guides/apis/descriptions/desc-state_target_instance.rst
+
+.. include:: /guides/apis/descriptions/desc-QARecommendation_target_instance.rst
+
+| **sortBy**
+| Name of field upon which the result set must be sorted. The field name must be followed by an indication if the sorting must be ascending (asc) or descending (desc).
+
+| Only sortable fields maybe given, others are ignored. Sortable fields are:
+| * name (default)
+| * harvestDate
+| * runtime
+| * dataDownloaded
+| * AmountUrls
+| * percentageFailed 
+| * AmountCrawls
+
+Only one sort field may be given as input. If multiple sort fields are given then this will result in an error. Example: sortBy=Name,asc
+
+.. include:: /guides/apis/descriptions/desc-request-offset.rst
+
+.. include:: /guides/apis/descriptions/desc-request-limit.rst
+
+Response
+--------
+200: OK
+
+========== ====== ========
+**Body**
+--------------------------
+filter     String Optional
+sortBy     String Optional
+offset     Number Optional
+limit	   Number Optional
+amount 	   Number Required
+instances  List   Optional
+========== ====== ========
+
+| **amount**
+| Number of total targets in the search result.  
+
+| **instances**
+| This is a list of found target instances. It could be that no target instances are returned.
+ 
+The following information is returned per found target instance:
+
+================ ====== ========
+**Body**
+--------------------------------
+id               Number Required
+thumbnail        Image  Optional
+harvestDate      Date   Required 
+name             String Required
+owner            String Required
+agency           String Optional
+state            Number Required
+runtime          Time   Optional
+dataDownloaded   Number Optional
+AmountUrls       Number Optional
+percentageFailed Number Optional
+AmountCrawls     Number Optional
+qaRecommendation String Optional
+flagId           Number Optional
+================ ====== ========
+
+| **harvestDate**
+.. include:: /guides/apis/descriptions/desc-formatDate.rst
+
+.. include:: /guides/apis/descriptions/desc-owner.rst
+
+.. include:: /guides/apis/descriptions/desc-state_target_instance.rst
+
+.. include:: /guides/apis/descriptions/desc-flagId.rst
+
+Errors
+------
+If any error is raised no output is returned.
+
+=== ========================================================================================
+400 Bad Request, including reason why e.g. Unsupported or malformed sort spec <sortBy field>
+403 Not authorized, user is no longer logged in.
+405 Method not allowed, only GET is allowed.
+=== ========================================================================================
+
+Example
+-------
+.. code-block:: linux
+
+  curl \
+  --location --request GET 'http://kb006561i.clients.wpakb.kb.nl:8080/wct/api/v1/target-instances' \
+  --header 'Content-Type: application/json' \
+  --header 'Authorization: Bearer FRnUvdZxlJcmvAoLXSqyzUbTW3qQPGhKN7M0nepKH9ZBcRkka1meaA5yxVMMK1T4' \
+  --data '{ "filter": { "nonDisplayOnly": false, "states": [5] }, "limit": 5 }'

--- a/webcurator-docs/guides/apis/api-target_scheduleTypes_GET.rst
+++ b/webcurator-docs/guides/apis/api-target_scheduleTypes_GET.rst
@@ -1,0 +1,56 @@
+Retrieve Target schedule types (GET)
+====================================
+
+Returns a list of all the schedule types that a target can have, including the description of each specific schedule type.
+
+Version
+-------
+1.0.0
+
+Request
+-------
+``https://--WCT_base--/api/v1/targets/schedule-types``
+
+Header
+------
+.. include:: /guides/apis/descriptions/desc-header-authentication.rst
+
+Body
+----
+.. include:: /guides/apis/descriptions/desc-request-body-empty.rst
+
+Response
+--------
+200: OK
+
+============= ==== ========
+**Body**
+---------------------------
+scheduleTypes List Required
+============= ==== ========
+
+| **scheduleTypes**
+| Is a list of all the scheduleTypes that a target can have, including the description of each specific schedule type.
+
+.. include:: /guides/apis/descriptions/desc-scheduleType.rst
+
+Errors
+------
+If any error is raised no output is returned.
+
+=== ========================================================================================
+400 Bad Request, including reason why e.g. Unsupported or malformed sort spec <sortBy field>
+403 Not authorized, user is no longer logged in.
+405 Method not allowed, only GET is allowed.
+=== ========================================================================================
+
+Example
+-------
+.. code-block:: linux
+
+  curl \
+  --location --request GET 'http://localhost/wct/api/v1/targets/schedule-types' \
+  --header 'Authorization: Bearer <token>' \
+  --header 'Content-Type: application/json' \
+  --data ''
+ 

--- a/webcurator-docs/guides/apis/api-target_states_GET.rst
+++ b/webcurator-docs/guides/apis/api-target_states_GET.rst
@@ -1,0 +1,54 @@
+Retrieve Target states (GET)
+============================
+
+Returns a list of all the states that a target can have, including the description of each specific state.
+
+Version
+-------
+1.0.0
+
+Request
+-------
+``https://--WCT_base--/api/v1/targets/states``
+
+Header
+------
+.. include:: /guides/apis/descriptions/desc-header-authentication.rst
+
+Body
+----
+.. include:: /guides/apis/descriptions/desc-request-body-empty.rst
+
+Response
+--------
+200: OK
+
+====== ==== ========
+**Body**
+--------------------
+states List Required
+====== ==== ========
+
+| **states**
+| Is a list of all the states that a target can have, including the description of each specific state.
+
+.. include:: /guides/apis/descriptions/desc-state_target.rst
+
+Errors
+------
+If any error is raised no output is returned.
+
+=== ========================================================================================
+400 Bad Request, including reason why e.g. Unsupported or malformed sort spec <sortBy field>
+403 Not authorized, user is no longer logged in.
+405 Method not allowed, only GET is allowed.
+=== ========================================================================================
+
+Example
+-------
+.. code-block:: linux
+
+  curl \
+  --location 'http://localhost/wct/api/v1/targets/states' \
+  --header 'Authorization: Bearer <token>'
+ 

--- a/webcurator-docs/guides/apis/api-targets_GET.rst
+++ b/webcurator-docs/guides/apis/api-targets_GET.rst
@@ -1,0 +1,139 @@
+Retrieve Targets (GET)
+======================
+Returns all targets with a subset of the available information based upon given filter and sorting.
+
+Version
+-------
+1.0.0
+
+Request
+-------
+``https://--WCT_base--/api/v1/targets``_
+
+Header
+------
+.. include:: /guides/apis/descriptions/desc-header-authentication.rst
+
+Body
+----
+.. include:: /guides/apis/descriptions/desc-query-method.rst
+
+====== ====== ========
+filter String Optional
+sortBy String Optional
+offset Number Optional
+limit  Number Optional
+====== ====== ========
+
+| **filter**
+| Name of field upon which the result set must be filtered. Only filterable fields maybe given, others are ignored. Filterable fields are:
+
+* targetId [exact match only]
+* name [contains text]
+* seed [contains text]
+* agency [exact match only]
+* userId [exact match only]
+* description [contains text]
+* groupName [contains text]
+* nonDisplayOnly [Boolean]
+* state [List of integers, exact match only]
+
+| Multiple filter fields may be given, but each field only once. If a filter field is given multiple times this will result in an error.
+|
+| With each field (key) a value must be given which is used to filter. The filter only shows those results that match or contains the given value in the given field. All given characters are used, there are no wild cards.
+
+.. include:: /guides/apis/descriptions/desc-userId.rst
+
+.. include:: /guides/apis/descriptions/desc-state_target.rst
+
+| **sortBy**
+| Name of field upon which the result set must be sorted. The field name must be followed by an indication if the sorting must be ascending (asc) or descending (desc).
+
+| Only sortable fields maybe given, others are ignored. Sortable fields are:
+| * name (default)
+| * creationDate
+
+Only one sort field may be given as input. If multiple sort fields are given then this will result in an error. Example: sortBy=Name,asc
+
+.. include:: /guides/apis/descriptions/desc-request-offset.rst
+
+.. include:: /guides/apis/descriptions/desc-request-limit.rst
+
+Response
+--------
+200: OK
+
+========== ====== ========
+**Body**
+--------------------------
+filter     String Optional
+sortBy     String Optional
+offset     Number Optional
+limit	   Number Optional
+amount 	   Number Required
+targets    List   Optional
+========== ====== ========
+
+| **amount**
+| Number of total targets in the search result.  
+
+| **targets**
+| This is a list of found targets. It could be that no targets are returned.
+ 
+The following information is returned per found target:
+
+============ ====== ========
+**Body**
+----------------------------
+targetId     Number Required
+creationDate Date   Required 
+name         String Required
+agency       String Required
+owner        String Required
+state        Number Required
+seeds        List   Required
+============ ====== ========
+
+| **creationDate**
+.. include:: /guides/apis/descriptions/desc-formatDate.rst
+
+.. include:: /guides/apis/descriptions/desc-state_target_response.rst
+
+| **seeds**
+| A list of seeds containing the following information:
+
+============== ======= ========
+**seeds**
+-------------------------------
+seed           URL     Required
+primary        Boolean Required
+============== ======= ========
+
+Errors
+------
+If any error is raised no output is returned.
+
+=== ========================================================================================
+400 Bad Request, including reason why e.g. Unsupported or malformed sort spec <sortBy field>
+403 Not authorized, user is no longer logged in.
+405 Method not allowed, only GET is allowed.
+=== ========================================================================================
+
+Example
+-------
+.. code-block:: linux
+
+  curl \
+  --location --request GET 'http://localhost/wct/api/v1/targets' \
+  --header 'Authorization: Bearer <token>' \
+  --header 'Content-Type: application/json' \
+  --data '{"filter": {"states": [5], "agency": "KB" }, "limit": 5, "sortBy": "creationDate,asc" }'
+
+.. code-block:: linux
+
+  curl \
+  --location 'http://localhost/wct/api/v1/targets' \
+  --header 'X-HTTP-Method-Override: GET' \
+  --header 'Authorization: Bearer <token>' \
+  --header 'Content-Type: application/json' \
+  --data '{"filter": {"states": [5], "agency": "KB" }, "limit": 5, "sortBy": "creationDate,asc" }'

--- a/webcurator-docs/guides/apis/api-users_GET.rst
+++ b/webcurator-docs/guides/apis/api-users_GET.rst
@@ -1,0 +1,83 @@
+Retrieve Users (GET)
+====================
+
+Returns all users with a subset of the available information based upon given filter and sorting.
+
+Version
+-------
+1.0.0
+
+Request
+-------
+``https://--WCT_base--/api/v1/users``
+
+Header
+------
+.. include:: /guides/apis/descriptions/desc-header-authentication.rst
+
+Body
+----
+.. include:: /guides/apis/descriptions/desc-query-method.rst
+
+====== ====== ========
+filter String Optional
+====== ====== ========
+
+| **filter**
+| Name of field upon which the result set must be filtered. Only filterable fields maybe given, others are ignored. Filterable fields are:
+
+* agency [exact match only]
+
+| With each filter field (key) a value must be given which is used to filter. The filter only shows those results that match or contains the given value in the given field. All given characters are used, there are no wild cards.
+
+Response
+--------
+200: OK
+
+========== ====== ========
+**Body**
+--------------------------
+filter     String Optional
+users      List   Optional
+========== ====== ========
+
+| **users**
+| This is a list of found users. It could be that no users are present. In that case an empty list is returned.
+ 
+The following information is returned per found user:
+
+============ ====== ========
+**Body**
+----------------------------
+userId       Number Required
+userName     String Required
+firstName    String Required
+lastName     String Required
+email        String Required
+agency       String Required
+============ ====== ========
+
+.. include:: /guides/apis/descriptions/desc-userId.rst
+
+Errors
+------
+If any error is raised no output is returned.
+
+=== ========================================================================================
+400 Bad Request, including reason why e.g. Unsupported or malformed sort spec <sortBy field>
+403 Not authorized, user is no longer logged in.
+405 Method not allowed, only GET is allowed.
+=== ========================================================================================
+
+Example
+-------
+.. code-block:: linux
+
+  curl \
+  --location --request GET 'http://localhost/wct/api/v1/users' \
+  --header 'Authorization: Bearer <token>' \
+  --header 'Content-Type: application/json' \
+  --data '{"filter": {"agency": "KB" } }'
+ 
+ 
+ 

--- a/webcurator-docs/guides/apis/descriptions/desc-QARecommendation_target_instance.rst
+++ b/webcurator-docs/guides/apis/descriptions/desc-QARecommendation_target_instance.rst
@@ -1,0 +1,7 @@
+| **QA Recommendations**
+| The Quaity Assurance Recommendation can have one of the following values:
+| * Archive
+| * Reject
+| * Investigate
+| * Delist
+| * Failed

--- a/webcurator-docs/guides/apis/descriptions/desc-cron.rst
+++ b/webcurator-docs/guides/apis/descriptions/desc-cron.rst
@@ -1,0 +1,4 @@
+| **cron**
+| This field has the cron information stored for a specific target. It is one string field which consists of the follwoing parts, seperated by a space: seconds, minutes, hours, days of month, months, days of week, years.
+
+The scheduling uses Cron expressions. For more information about how to use these expressions go to: `http://en.wikipedia.org/wiki/Cron <http://en.wikipedia.org/wiki/Cron>`_.

--- a/webcurator-docs/guides/apis/descriptions/desc-flagId.rst
+++ b/webcurator-docs/guides/apis/descriptions/desc-flagId.rst
@@ -1,0 +1,4 @@
+| **flagId**
+| The identifier of a flag.
+
+The list of all flag identiefiers can be retrieved with API :doc:`/guides/apis/api-flags_GET`.

--- a/webcurator-docs/guides/apis/descriptions/desc-formatDate.rst
+++ b/webcurator-docs/guides/apis/descriptions/desc-formatDate.rst
@@ -1,0 +1,1 @@
+| This field has the format: YYYY-MM-DD HH:MM:SS, E.g. 2020-09-24 10:31:33.

--- a/webcurator-docs/guides/apis/descriptions/desc-formatTime.rst
+++ b/webcurator-docs/guides/apis/descriptions/desc-formatTime.rst
@@ -1,0 +1,1 @@
+| This field has the format: HH:MM:SS, E.g. 10:31:33.

--- a/webcurator-docs/guides/apis/descriptions/desc-group_response.rst
+++ b/webcurator-docs/guides/apis/descriptions/desc-group_response.rst
@@ -1,0 +1,28 @@
+============ ======= ========
+**Body**
+-----------------------------
+general      List    Required
+members      List    Optional
+memberOf     List    Optional
+profile      List    Optional
+schedule     List    Optional
+annotations  List    Optional
+description  List    Optional
+access       List    Optional
+============ ======= ========
+
+.. include:: /guides/apis/descriptions/part-general_group_response.rst
+
+.. include:: /guides/apis/descriptions/part-members_group.rst
+
+.. include:: /guides/apis/descriptions/part-memberOf_group.rst
+
+.. include:: /guides/apis/descriptions/part-profile_target.rst
+
+.. include:: /guides/apis/descriptions/part-schedule_group.rst
+
+.. include:: /guides/apis/descriptions/part-annotations_group_response.rst
+
+.. include:: /guides/apis/descriptions/part-description_target.rst
+
+.. include:: /guides/apis/descriptions/part-access_target.rst

--- a/webcurator-docs/guides/apis/descriptions/desc-harvesterType.rst
+++ b/webcurator-docs/guides/apis/descriptions/desc-harvesterType.rst
@@ -1,0 +1,4 @@
+| **harvesterType**
+| The type of harvester, this can only be 'HERITRIX3' or 'HERITRIX1'.
+|
+| When inserting a new target only 'HERITRIX3' is allowed.

--- a/webcurator-docs/guides/apis/descriptions/desc-header-authentication.rst
+++ b/webcurator-docs/guides/apis/descriptions/desc-header-authentication.rst
@@ -1,0 +1,3 @@
+Authorization: Bearer {token}
+
+.. include:: /guides/apis/descriptions/desc-token.rst

--- a/webcurator-docs/guides/apis/descriptions/desc-overrides.rst
+++ b/webcurator-docs/guides/apis/descriptions/desc-overrides.rst
@@ -1,0 +1,22 @@
+| **overrides**
+| Required when imported is 'false'.
+
+A list of profile overwrites containing the following information:
+
+======= ========= ========
+**overwrites**
+--------------------------
+id      String    Required
+value   Dependent Optional
+unit    String    Optional
+enabled Boolean   Required
+======= ========= ========
+
+| **id**
+| The identifier of the overwrite in the WCT database. E.g. po_h3_time_limit.
+
+| **value**
+| The value type can be boolean, number, string or list. It is dependent on the specific override. E.g. the override for 'maxPathDepth' is a number, the override for 'includedUrls' is a List of Strings.
+
+| **unit**
+| Some overrides have specific units, E.g. 'SECONDS'.

--- a/webcurator-docs/guides/apis/descriptions/desc-owner.rst
+++ b/webcurator-docs/guides/apis/descriptions/desc-owner.rst
@@ -1,0 +1,4 @@
+| **owner**
+| The username of a user which is the owner of the piece of data.
+
+The list of all users can be retrieved with API :doc:`/guides/apis/api-users_GET`.

--- a/webcurator-docs/guides/apis/descriptions/desc-query-method.rst
+++ b/webcurator-docs/guides/apis/descriptions/desc-query-method.rst
@@ -1,0 +1,7 @@
+The body of the request contains the parameters voor the retrieval of the target instances. This has been done to 
+ensure that the length of the GET URL does not exceed the maximum length. There is currently a proposal for a new 
+HTTP method (QUERY) do support exactly this use case. However it is still in draft and is therfor not yet implemented. 
+For more information on HTTP Query method see: `https://www.ietf.org/archive/id/draft-ietf-httpbis-safe-method-w-body-03.html <https://www.ietf.org/archive/id/draft-ietf-httpbis-safe-method-w-body-03.html>`_.
+
+Having said this not all libraries and platforms allow the GET method to have anything in the body. In these situations this API also
+supports the HTTP method POST. The header must then contain the key 'X-HTTP-Method-Override' with the value equal to 'GET'.

--- a/webcurator-docs/guides/apis/descriptions/desc-request-body-empty.rst
+++ b/webcurator-docs/guides/apis/descriptions/desc-request-body-empty.rst
@@ -1,0 +1,1 @@
+The body of the request is empty. No additional information is required.

--- a/webcurator-docs/guides/apis/descriptions/desc-request-limit.rst
+++ b/webcurator-docs/guides/apis/descriptions/desc-request-limit.rst
@@ -1,0 +1,7 @@
+| **limit**
+| Number of records returned from the offset.
+| Default: 10
+| Minimum: 10
+| Maximum: 100
+ 
+This is the maximum amount of rows shown on a results page.

--- a/webcurator-docs/guides/apis/descriptions/desc-request-offset.rst
+++ b/webcurator-docs/guides/apis/descriptions/desc-request-offset.rst
@@ -1,0 +1,11 @@
+| **offset**
+| Specifies the number of rows in the result set to skip before limiting starts. 
+| Default: 0
+| Minimum: 0
+
+| The results page shown is equal to:
+| TRUNC(*offset* / *limit*) + 1
+ 
+So the if the *offset* value is not a multiple of the *limit* value then the results page shown is the page upon which the offset row is present. E.g. If *limit* is 10 and *offset* is 19 then the page shown is TRUNC(19/10) + 1 = 2.
+
+Issue: At this point in time *offset* **must** be a multiple of *limit*

--- a/webcurator-docs/guides/apis/descriptions/desc-response-body-empty.rst
+++ b/webcurator-docs/guides/apis/descriptions/desc-response-body-empty.rst
@@ -1,0 +1,1 @@
+The body of the response is empty.

--- a/webcurator-docs/guides/apis/descriptions/desc-scheduleType.rst
+++ b/webcurator-docs/guides/apis/descriptions/desc-scheduleType.rst
@@ -1,0 +1,18 @@
+| **type**
+| The schedule type of a target is an integer with the following values:
+
+======== ======================
+**Type** **Description**
+-------- ----------------------
+  1      Every Monday at 9:00pm
+  0      Custom
+ -1      Daily
+ -2      Weekly
+ -3      Monthly
+ -4      Bi-Monthly
+ -5      Quarterly
+ -6      Half Yearly
+ -7      Annually
+======== ======================
+
+The list of possible schedule type values for targets can be retrieved with API :doc:`/guides/apis/api-target_scheduleTypes_GET`.

--- a/webcurator-docs/guides/apis/descriptions/desc-state_group.rst
+++ b/webcurator-docs/guides/apis/descriptions/desc-state_group.rst
@@ -1,0 +1,12 @@
+| **state**
+| The state of a group is an integer with the following values:
+
+========= ===============
+**State** **Description**
+--------- ---------------
+  8       Pending
+  9       Active
+  10      Inactive
+========= ===============
+
+The list of possible state values for targets can be retrieved with API :doc:`/guides/apis/api-group_states_GET`.

--- a/webcurator-docs/guides/apis/descriptions/desc-state_harvest_authoristion.rst
+++ b/webcurator-docs/guides/apis/descriptions/desc-state_harvest_authoristion.rst
@@ -1,0 +1,13 @@
+| **permissionState**
+| The state of a harvest authorisation is an integer with the following values:
+
+========= ===============
+**State** **Description**
+--------- ---------------
+  0       Pending
+  1       Requested
+  2       Approved
+  3       Rejected
+========= ===============
+
+The list of possible state values for harvest authorisations can be retrieved with API :doc:`/guides/apis/api-harvest_authorisation_states_GET`.

--- a/webcurator-docs/guides/apis/descriptions/desc-state_harvest_result.rst
+++ b/webcurator-docs/guides/apis/descriptions/desc-state_harvest_result.rst
@@ -1,0 +1,16 @@
+| **state**
+| The state of a harvest result is an integer with the following values:
+
+========= ===============
+**State** **Description**
+--------- ---------------
+  0       Unassessed
+  1       Endorsed
+  2       Rejected
+  3       Indexing
+  4       Aborted
+  5       Crawling
+  6       Modifying
+========= ===============
+
+The list of possible state values for harvest results can be retrieved with API :doc:`/guides/apis/api-harvest_result_states_GET`.

--- a/webcurator-docs/guides/apis/descriptions/desc-state_profile.rst
+++ b/webcurator-docs/guides/apis/descriptions/desc-state_profile.rst
@@ -1,0 +1,12 @@
+| **state**
+| The state of a profile is an integer with the following values:
+
+========= ===============
+**State** **Description**
+--------- ---------------
+  0       Inactive
+  1       Active
+  2       Locked
+========= ===============
+
+The list of possible state values for profiles can be retrieved with API :doc:`/guides/apis/api-profile_states_GET`.

--- a/webcurator-docs/guides/apis/descriptions/desc-state_target.rst
+++ b/webcurator-docs/guides/apis/descriptions/desc-state_target.rst
@@ -1,0 +1,16 @@
+| **state**
+| The state of a target is an integer with the following values:
+
+========= ===============
+**State** **Description**
+--------- ---------------
+  1       Pending
+  2       Reinstated
+  3       Nominated
+  4       Rejected
+  5       Approved
+  6       Cancelled
+  7       Completed
+========= ===============
+
+The list of possible state values for targets can be retrieved with API :doc:`/guides/apis/api-target_states_GET`.

--- a/webcurator-docs/guides/apis/descriptions/desc-state_target_instance.rst
+++ b/webcurator-docs/guides/apis/descriptions/desc-state_target_instance.rst
@@ -1,0 +1,19 @@
+| **state**
+| The state of a target instance is an integer with the following values:
+
+========= ===============
+**State** **Description**
+--------- ---------------
+  1       Scheduled
+  2       Queued
+  3       Running
+  4       Paused
+  5       Harvested
+  6       Aborted
+  7       Endorsed
+  8       Rejected
+  9       Archived
+ 10       Archiving
+========= ===============
+
+The list of possible state values for targets can be retrieved with API :doc:`/guides/apis/api-target_instance_states_GET`.

--- a/webcurator-docs/guides/apis/descriptions/desc-systemGenerated.rst
+++ b/webcurator-docs/guides/apis/descriptions/desc-systemGenerated.rst
@@ -1,0 +1,1 @@
+This field is system generated on creation and may not be given when using POST (Create) or PUT (update).

--- a/webcurator-docs/guides/apis/descriptions/desc-target_instance_request.rst
+++ b/webcurator-docs/guides/apis/descriptions/desc-target_instance_request.rst
@@ -1,0 +1,44 @@
+================ ======= ========
+**Body**
+---------------------------------
+general          List    Optional
+harvest results  List    Optional
+annotations      List    Optional
+display          List    Optional
+================ ======= ========
+
+-----------------
+**part: general**
+-----------------
+A list of general properties that belong to a target instance. This contains the following information:
+
+=================== ======= ========
+**general**
+------------------------------------
+owner               String  Optional
+flagId              Number  Optional
+=================== ======= ========
+
+.. include:: /guides/apis/descriptions/desc-owner.rst
+
+.. include:: /guides/apis/descriptions/desc-flagId.rst
+
+-------------------------
+**part: harvest results**
+-------------------------
+A list of harvest results that belong to a target instance. This contains the following information:
+
+=============== ====== ========
+**harvest results**
+-------------------------------
+HarvestResultId Number Required
+state           Number Required
+=============== ====== ========
+
+.. include:: /guides/apis/descriptions/desc-state_harvest_result.rst
+
+When updating the field 'state' may only contain the values '1' or '2'. All other values are system set.
+
+.. include:: /guides/apis/descriptions/part-annotations_target_instance.rst
+
+.. include:: /guides/apis/descriptions/part-display_target_instance.rst

--- a/webcurator-docs/guides/apis/descriptions/desc-target_instance_response.rst
+++ b/webcurator-docs/guides/apis/descriptions/desc-target_instance_response.rst
@@ -1,0 +1,26 @@
+================ ======= ========
+**Body**
+---------------------------------
+general          List    Required
+profile          List    Optional
+harvestState     List    Optional
+logs             List    Optional
+harvestResults   List    Optional
+annotations      List    Optional
+display          List    Optional
+================ ======= ========
+
+
+.. include:: /guides/apis/descriptions/part-general_target_instance_response.rst
+
+.. include:: /guides/apis/descriptions/part-profile_target_instance.rst
+
+.. include:: /guides/apis/descriptions/part-harvestState_target_instance.rst
+
+.. include:: /guides/apis/descriptions/part-logs_target_instance.rst
+
+.. include:: /guides/apis/descriptions/part-harvestResults_target_instance.rst
+
+.. include:: /guides/apis/descriptions/part-annotations_target_instance.rst
+
+.. include:: /guides/apis/descriptions/part-display_target_instance.rst

--- a/webcurator-docs/guides/apis/descriptions/desc-target_request.rst
+++ b/webcurator-docs/guides/apis/descriptions/desc-target_request.rst
@@ -1,0 +1,28 @@
+============ ======= ========
+**Body**
+-----------------------------
+general      List    Required
+seeds        List    Optional
+profile      List    Optional
+schedule     List    Optional
+annotations  List    Optional
+description  List    Optional
+groups       List    Optional
+access       List    Optional
+============ ======= ========
+
+.. include:: /guides/apis/descriptions/part-general_target_request.rst
+
+.. include:: /guides/apis/descriptions/part-seeds_target.rst
+
+.. include:: /guides/apis/descriptions/part-profile_target.rst
+
+.. include:: /guides/apis/descriptions/part-schedule_target.rst
+
+.. include:: /guides/apis/descriptions/part-annotations_target_request.rst
+
+.. include:: /guides/apis/descriptions/part-description_target.rst
+
+.. include:: /guides/apis/descriptions/part-groups_target.rst
+
+.. include:: /guides/apis/descriptions/part-access_target.rst

--- a/webcurator-docs/guides/apis/descriptions/desc-target_response.rst
+++ b/webcurator-docs/guides/apis/descriptions/desc-target_response.rst
@@ -1,0 +1,28 @@
+============ ======= ========
+**Body**
+-----------------------------
+general      List    Required
+seeds        List    Optional
+profile      List    Optional
+schedule     List    Optional
+annotations  List    Optional
+description  List    Optional
+groups       List    Optional
+access       List    Optional
+============ ======= ========
+
+.. include:: /guides/apis/descriptions/part-general_target_response.rst
+
+.. include:: /guides/apis/descriptions/part-seeds_target.rst
+
+.. include:: /guides/apis/descriptions/part-profile_target.rst
+
+.. include:: /guides/apis/descriptions/part-schedule_target.rst
+
+.. include:: /guides/apis/descriptions/part-annotations_target_response.rst
+
+.. include:: /guides/apis/descriptions/part-description_target.rst
+
+.. include:: /guides/apis/descriptions/part-groups_target.rst
+
+.. include:: /guides/apis/descriptions/part-access_target.rst

--- a/webcurator-docs/guides/apis/descriptions/desc-token.rst
+++ b/webcurator-docs/guides/apis/descriptions/desc-token.rst
@@ -1,0 +1,2 @@
+| **token**
+| A token is obtained by a succesful login via the API :doc:`/guides/apis/api-authentication_POST`.

--- a/webcurator-docs/guides/apis/descriptions/desc-type_group.rst
+++ b/webcurator-docs/guides/apis/descriptions/desc-type_group.rst
@@ -1,0 +1,11 @@
+| **type**
+| The type of a group is an string with the following values:
+
+* collection
+* event
+* functional
+* sub-group
+* subject
+* thematic
+
+The list of possible state values for targets can be retrieved with API :doc:`/guides/apis/api-group_types_GET`.

--- a/webcurator-docs/guides/apis/descriptions/desc-user.rst
+++ b/webcurator-docs/guides/apis/descriptions/desc-user.rst
@@ -1,0 +1,4 @@
+| **user**
+| The username of a user which is the owner of the piece of data.
+
+The list of all users can be retrieved with API :doc:`/guides/apis/api-users_GET`.

--- a/webcurator-docs/guides/apis/descriptions/desc-userId.rst
+++ b/webcurator-docs/guides/apis/descriptions/desc-userId.rst
@@ -1,0 +1,4 @@
+| **userId**
+| The identifier of a user.
+
+The list of all users can be retrieved with API :doc:`/guides/apis/api-users_GET`.

--- a/webcurator-docs/guides/apis/descriptions/part-access_target.rst
+++ b/webcurator-docs/guides/apis/descriptions/part-access_target.rst
@@ -1,0 +1,30 @@
+----------------
+**part: access**
+----------------
+A list of access properties that belong to a target or group. This contains the following information:
+
+=================== ======= ========
+**access**
+------------------------------------
+displayTarget       Boolean Required
+accessZone          Number  Required
+accessZoneText      String  Required
+displayChangeReason String  Optional
+displayNote         String  Optional
+=================== ======= ========
+
+| **accessZone**
+| The access zone of a target is an integer with the following values:
+
+======== ===============
+**Zone** **Description**
+-------- ---------------
+  0      Public
+  1      Onsite
+  2      Restricted
+======== ===============
+
+| **accessZoneText**
+| Contains one of the following: Public, Onsite, Restricted, based upon the integer in accessZone.
+
+.. include:: /guides/apis/descriptions/desc-systemGenerated.rst

--- a/webcurator-docs/guides/apis/descriptions/part-annotations_group_response.rst
+++ b/webcurator-docs/guides/apis/descriptions/part-annotations_group_response.rst
@@ -1,0 +1,26 @@
+---------------------
+**part: annotations**
+---------------------
+A list of annotations properties that belong to a group. This contains the following information:
+
+============== ====== ========
+**annotations**
+------------------------------ 
+annotations    List   Optional
+============== ====== ========
+
+| **annotations**
+| A list of annotations containing the following information:
+
+===== ======= ========
+**annotations**
+---------------------- 
+date  Date    Required
+note  String  Required
+user  String  Required
+===== ======= ========
+
+| **date**
+.. include:: /guides/apis/descriptions/desc-formatDate.rst
+
+.. include:: /guides/apis/descriptions/desc-user.rst

--- a/webcurator-docs/guides/apis/descriptions/part-annotations_target_instance.rst
+++ b/webcurator-docs/guides/apis/descriptions/part-annotations_target_instance.rst
@@ -1,0 +1,16 @@
+---------------------
+**part: annotations**
+---------------------
+A list of annotations that belong to a target instance. This contains the following information:
+
+============ ======= ========
+**annotations**
+-----------------------------
+date         Date    Required
+user         String  Required
+note         String  Required
+alert        Boolean Required
+============ ======= ========
+
+| **creationDate**
+.. include:: /guides/apis/descriptions/desc-formatDate.rst

--- a/webcurator-docs/guides/apis/descriptions/part-annotations_target_request.rst
+++ b/webcurator-docs/guides/apis/descriptions/part-annotations_target_request.rst
@@ -1,0 +1,41 @@
+---------------------
+**part: annotations**
+---------------------
+A list of annotations properties that belong to a target. This contains the following information:
+
+============== ====== ========
+**annotations**
+------------------------------ 
+evaluationNote String Optional
+harvestType    String Optional
+annotations    List   Optional
+selection      List   Required
+============== ====== ========
+
+| **harvestType**
+| Contains one of the following: Event, Subject, Team
+
+| **annotations**
+| A list of annotations containing the following information:
+
+===== ======= ========
+**annotations**
+---------------------- 
+note  String  Required
+alert Boolean Required
+===== ======= ========
+			
+---------------------
+**part: selection**
+---------------------
+Contains the following information:
+
+==== ====== ========
+**selection**
+--------------------
+type String Optional
+note String Optional
+==== ====== ========
+
+| **type**
+| Contains one of the following: Area, Collection, Other collections, Producer type, Publication type.

--- a/webcurator-docs/guides/apis/descriptions/part-annotations_target_response.rst
+++ b/webcurator-docs/guides/apis/descriptions/part-annotations_target_response.rst
@@ -1,0 +1,52 @@
+---------------------
+**part: annotations**
+---------------------
+A list of annotations properties that belong to a target. This contains the following information:
+
+============== ====== ========
+**annotations**
+------------------------------ 
+evaluationNote String Optional
+harvestType    String Optional
+annotations    List   Optional
+selection      List   Required
+============== ====== ========
+
+| **harvestType**
+| Contains one of the following: Event, Subject, Team
+
+| **annotations**
+| A list of annotations containing the following information:
+
+===== ======= ========
+**annotations**
+---------------------- 
+date  Date    Required
+note  String  Required
+user  String  Required
+alert Boolean Required
+===== ======= ========
+
+| **date**
+.. include:: /guides/apis/descriptions/desc-formatDate.rst
+
+.. include:: /guides/apis/descriptions/desc-user.rst
+			
+---------------------
+**Part: selection**
+---------------------
+Contains the following information:
+
+==== ====== ========
+**selection**
+--------------------
+date Date   Required
+type String Optional
+note String Optional
+==== ====== ========
+
+| **date**
+.. include:: /guides/apis/descriptions/desc-formatDate.rst
+
+| **type**
+| Contains one of the following: Area, Collection, Other collections, Producer type, Publication type.

--- a/webcurator-docs/guides/apis/descriptions/part-description_target.rst
+++ b/webcurator-docs/guides/apis/descriptions/part-description_target.rst
@@ -1,0 +1,23 @@
+---------------------
+**part: description**
+---------------------
+A list of description properties that belong to a target or group and are used for Dublin Core generation on archiving. This contains the following information:
+
+============ ======= ========
+**description**
+-----------------------------
+identifier   String  Optional
+description  Text    Optional
+subject      Text    Optional
+creator      String  Optional
+publisher    String  Optional
+contributer  String  Optional
+type         String  Optional
+format       String  Optional
+source       String  Optional
+language     String  Optional
+relation     String  Optional
+coverage     String  Optional
+issn         String  Optional
+isbn         String  Optional
+============ ======= ========

--- a/webcurator-docs/guides/apis/descriptions/part-display_target_instance.rst
+++ b/webcurator-docs/guides/apis/descriptions/part-display_target_instance.rst
@@ -1,0 +1,12 @@
+-----------------
+**part: display**
+-----------------
+The display properties that belong to a target instance. This contains the following information:
+
+===================== ======= ========
+**display**
+--------------------------------------
+displayTargetInstance Boolean Required
+displayChangeReason   String  Optional
+displayNote           String  Optional
+===================== ======= ========

--- a/webcurator-docs/guides/apis/descriptions/part-general_group_response.rst
+++ b/webcurator-docs/guides/apis/descriptions/part-general_group_response.rst
@@ -1,0 +1,34 @@
+-----------------
+**part: general**
+-----------------
+A list of general properties that belong to a group. This contains the following information:
+
+=============== ====== ========
+**general**
+--------------------------------
+id              Number Required
+name            String Required
+description     String Optional
+referenceNumber String Optional
+type            String Optional
+owner           String Required
+owner_info      String Optional  
+dateFrom        Date   Required
+dateTo          Date   Optional
+harvestType     Number Required
+=============== ====== ========
+
+.. include:: /guides/apis/descriptions/desc-type_group.rst
+
+.. include:: /guides/apis/descriptions/desc-owner.rst
+
+| **dateFrom**
+.. include:: /guides/apis/descriptions/desc-formatDate.rst
+
+| **dateTo**
+.. include:: /guides/apis/descriptions/desc-formatDate.rst
+
+| **harvestType**
+Can have the follwing values:
+*1 => Generate a single Harvest Result for this group [default]
+*2 => Generate one Harvest Result per member

--- a/webcurator-docs/guides/apis/descriptions/part-general_target_instance_response.rst
+++ b/webcurator-docs/guides/apis/descriptions/part-general_target_instance_response.rst
@@ -1,0 +1,35 @@
+-----------------
+**part: general**
+-----------------
+A list of general properties that belong to a target instance. This contains the following information:
+
+=================== ======= ========
+**general**
+------------------------------------
+id                  Number  Required
+name                String  Required
+scheduleStartDate   Date    Required
+actualStartDate     Date    Optional
+priority            String  Required
+owner               String  Required
+agency              String  Required
+state               Number  Required
+automatedQA         Boolean Required
+bandwidthPercentage String  Required
+flagId              Number  Required
+=================== ======= ========
+
+| **scheduleStartDate**
+.. include:: /guides/apis/descriptions/desc-formatDate.rst
+
+| **actualStartDate**
+.. include:: /guides/apis/descriptions/desc-formatDate.rst
+
+.. include:: /guides/apis/descriptions/desc-owner.rst
+
+.. include:: /guides/apis/descriptions/desc-state_target_instance.rst
+
+| **automatedQA**
+| The default is 'false'.
+
+.. include:: /guides/apis/descriptions/desc-flagId.rst

--- a/webcurator-docs/guides/apis/descriptions/part-general_target_request.rst
+++ b/webcurator-docs/guides/apis/descriptions/part-general_target_request.rst
@@ -1,0 +1,37 @@
+-----------------
+**part: general**
+-----------------
+A list of general properties that belong to a target. This contains the following information:
+
+=================== ======= ========
+**general**
+------------------------------------
+name                String  Required
+description         String  Optional
+referenceNumber     String  Optional
+RunOnApproval       Boolean Required
+automatedQA         Boolean Required
+owner               String  Required
+state               Number  Required
+autoPrune           Boolean Required
+referencdCrawl      Boolean Required
+requestToArchivists String  Optional
+=================== ======= ========
+
+.. include:: /guides/apis/descriptions/desc-owner.rst
+
+.. include:: /guides/apis/descriptions/desc-state_target.rst
+
+| **RunOnApproval**
+| The default is 'false'.
+
+| **automatedQA**
+| The default is 'false'.
+
+.. include:: /guides/apis/descriptions/desc-state_target.rst
+
+| **autoPrune**
+| The default is 'false'.
+
+| **refCrawl**
+| The default is 'false'.

--- a/webcurator-docs/guides/apis/descriptions/part-general_target_response.rst
+++ b/webcurator-docs/guides/apis/descriptions/part-general_target_response.rst
@@ -1,0 +1,42 @@
+-----------------
+**part: general**
+-----------------
+A list of general properties that belong to a target. This contains the following information:
+
+=================== ======= ========
+**general**
+------------------------------------
+id                  Number  Required
+creationDate        Date    Required
+name                String  Required
+description         String  Optional
+referenceNumber     String  Optional
+RunOnApproval       Boolean Required
+automatedQA         Boolean Required
+owner               String  Required
+state               Number  Required
+autoPrune           Boolean Required
+referencdCrawl      Boolean Required
+requestToArchivists String  Optional
+=================== ======= ========
+
+| **creationDate**
+.. include:: /guides/apis/descriptions/desc-formatDate.rst
+
+.. include:: /guides/apis/descriptions/desc-owner.rst
+
+.. include:: /guides/apis/descriptions/desc-state_target.rst
+
+| **RunOnApproval**
+| The default is 'false'.
+
+| **automatedQA**
+| The default is 'false'.
+
+.. include:: /guides/apis/descriptions/desc-state_target.rst
+
+| **autoPrune**
+| The default is 'false'.
+
+| **refCrawl**
+| The default is 'false'.

--- a/webcurator-docs/guides/apis/descriptions/part-groups_target.rst
+++ b/webcurator-docs/guides/apis/descriptions/part-groups_target.rst
@@ -1,0 +1,12 @@
+----------------
+**part: groups**
+----------------
+A list of groups properties that belong to a target. Each group in the list contains the following information:
+
+===== ====== ========
+**groups**
+---------------------
+id    Number Required
+===== ====== ========
+
+The list of all groups can be retrieved with API :doc:`/guides/apis/api-groups_GET`.

--- a/webcurator-docs/guides/apis/descriptions/part-harvestResults_target_instance.rst
+++ b/webcurator-docs/guides/apis/descriptions/part-harvestResults_target_instance.rst
@@ -1,0 +1,23 @@
+-------------------------
+**part: harvest results**
+-------------------------
+A list of harvest results that belong to a target instance. This contains the following information:
+
+=============== ====== ========
+**harvest results**
+-------------------------------
+id              Number Required
+number          Number Required
+creationDate    Date   Required
+derivedFrom     Number Required
+owner           String Required
+note            String Optional
+state           Number Required
+=============== ====== ========
+
+| **creationDate**
+.. include:: /guides/apis/descriptions/desc-formatDate.rst
+
+.. include:: /guides/apis/descriptions/desc-owner.rst
+
+.. include:: /guides/apis/descriptions/desc-state_harvest_result.rst

--- a/webcurator-docs/guides/apis/descriptions/part-harvestState_target_instance.rst
+++ b/webcurator-docs/guides/apis/descriptions/part-harvestState_target_instance.rst
@@ -1,0 +1,23 @@
+-----------------------
+**part: harvest state**
+-----------------------
+A list of harvest state properties that belong to a target instanace. This contains the following information:
+
+==================== ====== ========
+**harvest state**
+------------------------------------
+wctVersion           String Required
+captureSystem        String Required
+harvestServer        String Required
+job                  Number Required
+status               String Required
+averageKbsPerSecond  Number Required
+averageUrisPerSecond Number Required
+urlsDownloaded       Number Required
+urlsFailed           Number Required
+dataDownloaded       String Required
+elapsedTime          Time   Required
+==================== ====== ========
+
+| **ElapsedTime**
+.. include:: /guides/apis/descriptions/desc-formatTime.rst

--- a/webcurator-docs/guides/apis/descriptions/part-logs_target_instance.rst
+++ b/webcurator-docs/guides/apis/descriptions/part-logs_target_instance.rst
@@ -1,0 +1,12 @@
+--------------
+**part: logs**
+--------------
+A list of logs that belong to a target instanace. This contains the following information:
+
+======== ====== ========
+**logs**
+------------------------
+logfile  String Required
+location String Required
+size     String Required
+======== ====== ========

--- a/webcurator-docs/guides/apis/descriptions/part-memberOf_group.rst
+++ b/webcurator-docs/guides/apis/descriptions/part-memberOf_group.rst
@@ -1,0 +1,18 @@
+------------------
+**part: memberOf**
+------------------
+A list of groups that this group belongs to. This contains the following information:
+
+==== ====== ========
+**members**
+--------------------
+id   Number Required
+type String Required
+name String Required
+==== ====== ========
+
+| **id**
+This is the group identifier.
+
+| **type**
+This is always 'group'.

--- a/webcurator-docs/guides/apis/descriptions/part-members_group.rst
+++ b/webcurator-docs/guides/apis/descriptions/part-members_group.rst
@@ -1,0 +1,18 @@
+-----------------
+**part: members**
+-----------------
+A list of members that belong to a group. This contains the following information:
+
+==== ====== ========
+**members**
+--------------------
+id   Number Required
+type String Required
+name String Required
+==== ====== ========
+
+| **id**
+This is either the group or target identifier.
+
+| **type**
+This can be either 'group' or 'target'.

--- a/webcurator-docs/guides/apis/descriptions/part-profile_target.rst
+++ b/webcurator-docs/guides/apis/descriptions/part-profile_target.rst
@@ -1,0 +1,25 @@
+-----------------
+**part: profile**
+-----------------
+A list of profile properties that belongs to a target or group. This contains the following information:
+
+=============== ======= ========
+**profile**
+--------------------------------
+id              Number  Required
+imported        Boolean Required
+harvesterType   Number  Required
+name            String  Required
+overrides       List    Optional
+profile         String  Optional
+=============== ======= ========
+
+| **id**
+| A list of all profiles, with their id and name, can be retrieved with the API :doc: `/guides/apis/api-profiles_GET`.
+
+.. include:: /guides/apis/descriptions/desc-harvesterType.rst
+
+.. include:: /guides/apis/descriptions/desc-overrides.rst
+
+| **profile**
+| Required when imported is 'true'. This then contains the imported profile as-is.

--- a/webcurator-docs/guides/apis/descriptions/part-profile_target_instance.rst
+++ b/webcurator-docs/guides/apis/descriptions/part-profile_target_instance.rst
@@ -1,0 +1,24 @@
+-----------------
+**part: profile**
+-----------------
+A list of profile properties that belong to a target instanace. This contains the following information:
+
+=============== ======= ========
+**profile**
+--------------------------------
+id              Number  Required
+imported        Boolean Required
+harvesterType   String  Required
+name            String  Required
+overrides       List    Optional
+=============== ======= ========
+
+| **id**
+| A list of all profiles, with their id and name, can be retrieved with the API :doc: `/guides/apis/api-profiles_GET`.
+
+.. include:: /guides/apis/descriptions/desc-harvesterType.rst
+
+.. include:: /guides/apis/descriptions/desc-overrides.rst
+
+| **profile**
+| Required when imported is 'true'. This then contains the imported profile as-is.

--- a/webcurator-docs/guides/apis/descriptions/part-schedule_group.rst
+++ b/webcurator-docs/guides/apis/descriptions/part-schedule_group.rst
@@ -1,0 +1,47 @@
+------------------
+**part: schedule**
+------------------
+Consists of the following information:
+
+=================== ======= ========
+**schedule**
+------------------------------------
+schedules           List    Optional
+=================== ======= ========
+
+| **schedules**
+| A list of schedules that belong to a target containing the following information:
+
+================= ======= ========
+**schedules**
+----------------------------------
+id                Number  Required
+cron              String  Required
+startDate         Date    Required
+endDate           Date    Optional
+type              Number  Required
+owner             String  Required
+nextExecutionDate Date    Required
+lastExecutionDate Date    Optional
+================= ======= ========
+
+| **id**
+.. include:: /guides/apis/descriptions/desc-systemGenerated.rst
+
+.. include:: /guides/apis/descriptions/desc-cron.rst
+
+| **startDate** 
+.. include:: /guides/apis/descriptions/desc-formatDate.rst
+
+| **endDate** 
+.. include:: /guides/apis/descriptions/desc-formatDate.rst
+
+.. include:: /guides/apis/descriptions/desc-scheduleType.rst
+
+.. include:: /guides/apis/descriptions/desc-owner.rst
+
+| **nextExecutionDate** 
+.. include:: /guides/apis/descriptions/desc-formatDate.rst
+
+| **lastExecutionDate** 
+.. include:: /guides/apis/descriptions/desc-formatDate.rst

--- a/webcurator-docs/guides/apis/descriptions/part-schedule_target.rst
+++ b/webcurator-docs/guides/apis/descriptions/part-schedule_target.rst
@@ -1,0 +1,49 @@
+------------------
+**part: schedule**
+------------------
+Consists of the following information:
+
+=================== ======= ========
+**schedule**
+------------------------------------
+harvestOptimization Boolean Optional
+harvestNow          Boolean Optional
+schedules           List    Optional
+=================== ======= ========
+
+| **schedules**
+| A list of schedules that belong to a target containing the following information:
+
+================= ======= ========
+**schedules**
+----------------------------------
+id                Number  Required
+cron              String  Required
+startDate         Date    Required
+endDate           Date    Optional
+type              Number  Required
+owner             String  Required
+nextExecutionDate Date    Required
+lastExecutionDate Date    Optional
+================= ======= ========
+
+| **id**
+.. include:: /guides/apis/descriptions/desc-systemGenerated.rst
+
+.. include:: /guides/apis/descriptions/desc-cron.rst
+
+| **startDate** 
+.. include:: /guides/apis/descriptions/desc-formatDate.rst
+
+| **endDate** 
+.. include:: /guides/apis/descriptions/desc-formatDate.rst
+
+.. include:: /guides/apis/descriptions/desc-scheduleType.rst
+
+.. include:: /guides/apis/descriptions/desc-owner.rst
+
+| **nextExecutionDate** 
+.. include:: /guides/apis/descriptions/desc-formatDate.rst
+
+| **lastExecutionDate** 
+.. include:: /guides/apis/descriptions/desc-formatDate.rst

--- a/webcurator-docs/guides/apis/descriptions/part-seeds_target.rst
+++ b/webcurator-docs/guides/apis/descriptions/part-seeds_target.rst
@@ -1,0 +1,22 @@
+---------------
+**part: seeds**
+---------------
+A list of seeds that belong to a target containing the following information:
+
+============== ======= ========
+**seeds**
+-------------------------------
+id             Number  Required
+seed           URL     Required
+primary        Boolean Required
+authorisations List    Required
+============== ======= ========
+
+| **id**
+.. include:: /guides/apis/descriptions/desc-systemGenerated.rst
+
+| **primary**
+| This indicates if a seed is the primary seed, or not. There can only be one primary seed. Default is 'false'.
+
+| **authorisations**
+| A list of identifiers of harvest authorisations. The harvest authorisation information itself can be retrivied with the API :doc:`/guides/apis/api-harvest_authorisation_GET`_.

--- a/webcurator-docs/index.rst
+++ b/webcurator-docs/index.rst
@@ -35,6 +35,15 @@ Web Curator Tool Documentation
 
 .. toctree::
    :maxdepth: 1
+   :caption: Rest API
+
+   guides/api-introduction.rst
+   guides/api-principles.rst
+   guides/api-release-notes.rst
+   guides/apis/api-overview.rst
+
+.. toctree::
+   :maxdepth: 1
    :caption: Developers
 
    guides/developer-guide


### PR DESCRIPTION
I've integrated the ReST API documentation from https://wct-api.readthedocs.io/en/latest/. The bulk of the docs resides in the new subdirectory /guides/apis.