### PR TITLE
ReST API: Allow integer values for double precision fields

### DIFF
--- a/webcurator-core/src/main/java/org/webcurator/domain/model/core/ProfileOverrides.java
+++ b/webcurator-core/src/main/java/org/webcurator/domain/model/core/ProfileOverrides.java
@@ -906,6 +906,13 @@ public class ProfileOverrides {
 	}
 
 	/**
+	 * @param h3DataLimit The h3DataLimit to set.
+	 */
+	public void setH3DataLimit(Long h3DataLimit) {
+		this.h3DataLimit = h3DataLimit.doubleValue();
+	}
+
+	/**
 	 * @return Returns the overrideH3DataLimit.
 	 */
 	public boolean isOverrideH3DataLimit() {
@@ -945,6 +952,13 @@ public class ProfileOverrides {
 	 */
 	public void setH3TimeLimit(Double h3TimeLimit) {
 		this.h3TimeLimit = h3TimeLimit;
+	}
+
+	/**
+	 * @param h3TimeLimit The h3TimeLimit to set.
+	 */
+	public void setH3TimeLimit(Long h3TimeLimit) {
+		this.h3TimeLimit = h3TimeLimit.doubleValue();
 	}
 
 	/**

--- a/webcurator-webapp/rest-api-tests/put-target.json
+++ b/webcurator-webapp/rest-api-tests/put-target.json
@@ -2,5 +2,16 @@
 "general":
 	{
 		"description": "Updated description"
+	},
+"profile":
+	{
+		"overrides": [
+				{
+			       		"id": "dataLimit",
+					"unit": "GB",
+        				"value": 1,
+        				"enabled": false
+     				}
+			     ]
 	}
 }


### PR DESCRIPTION
This is a workaround for JavaScript clients converting .0 values to integers.