### PR TITLE
ReST API: add extra attributes to harvest authorisations and targets

### DIFF
--- a/webcurator-ui/.gitignore
+++ b/webcurator-ui/.gitignore
@@ -9,6 +9,7 @@ lerna-debug.log*
 
 node_modules/
 .DS_Store
+.npmrc
 dist
 dist-ssr
 coverage

--- a/webcurator-ui/src/stores/target.ts
+++ b/webcurator-ui/src/stores/target.ts
@@ -31,13 +31,11 @@ export const initNewTarget = () => {
     useTargetAccessDTO().initData();
 }
 
-export const setTarget = (target: Target) => {
-    console.log(target);
-    
+export const setTarget = (target: Target) => {    
     useTargetDescriptionDTO().setData(target.description);
     useTargetGeneralDTO().setData(target.general);
     useTargetGropusDTO().setData(target.groups);
-    useTargetProfileDTO().setData(target.profile);
+    target.profile != null && useTargetProfileDTO().setData(target.profile);
     useTargetSeedsDTO().setData(target.seeds);
     useTargetAccessDTO().setData(target.access);
 }

--- a/webcurator-ui/src/views/target/TargetList.vue
+++ b/webcurator-ui/src/views/target/TargetList.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch, onMounted, computed } from 'vue'
+import { ref, watch, onMounted } from 'vue'
 import { useRouter } from 'vue-router';
 import { useConfirm } from "primevue/useconfirm";
 import { useToast } from "primevue/usetoast";
@@ -15,10 +15,6 @@ import PageHeader from '@/components/PageHeader.vue'
 const router = useRouter()
 const confirm = useConfirm();
 const toast = useToast();
-
-const options = defineProps(['props'])
-
-const emit = defineEmits(['popPage'])
 
 const rest: UseFetchApis = useFetch()
 const userProfile = useUserProfileStore()
@@ -92,7 +88,7 @@ const search = () => {
 
   loadingTargetList.value = true
   rest
-    .post('targets', searchParams)
+    .post('targets', searchParams, { header: 'X-HTTP-Method-Override', value: 'GET' })
     .then((data: any) => {
       console.log(data)
       targetList.value = data['targets']

--- a/webcurator-ui/src/views/target/TargetNew.vue
+++ b/webcurator-ui/src/views/target/TargetNew.vue
@@ -44,7 +44,7 @@ const save = () => {
         dataReq.profile = targetProfile.getData();
     }
 
-    rest.post('targets/save', dataReq)
+    rest.post('targets', dataReq)
     .then((data: any) => {
         console.log(data)
     })

--- a/webcurator-webapp/rest-api-tests/post-target-template.json
+++ b/webcurator-webapp/rest-api-tests/post-target-template.json
@@ -31,7 +31,7 @@
   "seeds": [
     {
       "seed": "https://www.dbnl.org/",
-      "authorisations": [$authorisationId],
+      "authorisations": [{"id": $authorisationId}],
       "primary": "true"
     }
   ],

--- a/webcurator-webapp/src/main/java/org/webcurator/rest/HarvestAuthorisations.java
+++ b/webcurator-webapp/src/main/java/org/webcurator/rest/HarvestAuthorisations.java
@@ -13,6 +13,7 @@ import org.webcurator.domain.SiteDAO;
 import org.webcurator.domain.model.core.AuthorisingAgent;
 import org.webcurator.domain.model.core.Permission;
 import org.webcurator.domain.model.core.Site;
+import org.webcurator.domain.model.core.UrlPattern;
 import org.webcurator.rest.common.BadRequestError;
 import org.webcurator.rest.common.Utils;
 
@@ -154,17 +155,29 @@ public class HarvestAuthorisations {
         summary.put("id", site.getOid());
         summary.put("creationDate", site.getCreationDate());
         summary.put("name", site.getTitle());
-        Set<Long> authorisingAgents = new HashSet<>();
+        Set<HashMap<String, Object>> authorisingAgents = new HashSet<>();
         for (AuthorisingAgent authorisingAgent : site.getAuthorisingAgents()) {
-            authorisingAgents.add(authorisingAgent.getOid());
+            HashMap<String, Object> agent = new HashMap<>();
+            agent.put("id", authorisingAgent.getOid());
+            agent.put("name", authorisingAgent.getName());
+            authorisingAgents.add(agent);
         }
         summary.put("authorisingAgents", authorisingAgents);
         summary.put("orderNo", site.getLibraryOrderNo());
-        Set<Integer> permissionStates = new HashSet<>();
-        for (Permission permission : site.getPermissions()) {
-            permissionStates.add(permission.getStatus());
+        Set<HashMap<String, Object>> permissions = new HashSet<>();
+        for (Permission p : site.getPermissions()) {
+            HashMap<String, Object> permission = new HashMap<>();
+            permission.put("status", p.getStatus());
+            permission.put("startDate", p.getStartDate());
+            permission.put("endDate", p.getEndDate());
+            List<String> urlPatterns = new ArrayList<>();
+            for (UrlPattern u : p.getUrls()) {
+                urlPatterns.add(u.getPattern());
+            }
+            permission.put("urlPatterns", urlPatterns);
+            permissions.add(permission);
         }
-        summary.put("permissionStates", permissionStates);
+        summary.put("permissions", permissions);
         return summary;
     }
 

--- a/webcurator-webapp/src/main/java/org/webcurator/rest/Targets.java
+++ b/webcurator-webapp/src/main/java/org/webcurator/rest/Targets.java
@@ -354,9 +354,9 @@ public class Targets {
                 seed.setSeed(s.getSeed());
                 seed.setPrimary(s.getPrimary());
                 Set<Permission> permissions = new HashSet<>();
-                for (long authorisation : s.getAuthorisations()) {
+                for (TargetDTO.Seed.Authorisation authorisation : s.getAuthorisations()) {
                     try {
-                        Site site = siteDAO.load(authorisation);
+                        Site site = siteDAO.load(authorisation.getId());
                         for (Permission p : site.getPermissions()) {
                             permissions.add(p);
                         }

--- a/webcurator-webapp/src/main/java/org/webcurator/rest/dto/TargetDTO.java
+++ b/webcurator-webapp/src/main/java/org/webcurator/rest/dto/TargetDTO.java
@@ -9,6 +9,7 @@ import javax.validation.Valid;
 import javax.validation.constraints.*;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 //import java.util.TimeZone;
 
@@ -475,7 +476,7 @@ public class TargetDTO {
         @NotNull(message = "primary is required")
         Boolean primary;
         @NotEmpty(message = "authorisations may not be empty")
-        List<Long> authorisations = new ArrayList<>();
+        List<Authorisation> authorisations = new ArrayList<>();
 
         public Seed() {
         }
@@ -485,9 +486,14 @@ public class TargetDTO {
             seed = s.getSeed();
             primary = s.isPrimary();
             for (Permission p : s.getPermissions()) {
-                Long authorisation = p.getSite().getOid();
+                Authorisation authorisation = new Authorisation();
+                authorisation.setId(p.getSite().getOid());
+                authorisation.setName(p.getSite().getTitle());
+                authorisation.setAgent(p.getAuthorisingAgent().getName());
+                authorisation.setStartDate(p.getStartDate());
+                authorisation.setEndDate(p.getEndDate());
                 if (!authorisations.contains(authorisation)) {
-                    authorisations.add(p.getSite().getOid());
+                    authorisations.add(authorisation);
                 }
             }
         }
@@ -516,12 +522,67 @@ public class TargetDTO {
             this.primary = primary;
         }
 
-        public List<Long> getAuthorisations() {
+        public List<Authorisation> getAuthorisations() {
             return authorisations;
         }
 
-        public void setAuthorisations(List<Long> authorisations) {
+        public void setAuthorisations(List<Authorisation> authorisations) {
             this.authorisations = authorisations;
+        }
+
+        public static class Authorisation {
+            long id;
+            String name;
+            String agent;
+            Date startDate;
+            Date endDate;
+
+            public Authorisation() {}
+
+            public long getId() {
+                return id;
+            }
+
+            public void setId(long id) {
+                this.id = id;
+            }
+
+            public String getAgent() {
+                return agent;
+            }
+
+            public void setAgent(String agent) {
+                this.agent = agent;
+            }
+
+            public Date getStartDate() {
+                return startDate;
+            }
+
+            public void setStartDate(Date startDate) {
+                this.startDate = startDate;
+            }
+
+            public Date getEndDate() {
+                return endDate;
+            }
+
+            public void setEndDate(Date endDate) {
+                this.endDate = endDate;
+            }
+
+            public String getName() {
+                return name;
+            }
+
+            public void setName(String name) {
+                this.name = name;
+            }
+
+            @Override
+            public boolean equals(Object other) {
+                return this.id == ((Authorisation)other).id;
+            }
         }
     }
 

--- a/webcurator-webapp/src/main/java/org/webcurator/rest/dto/TargetDTO.java
+++ b/webcurator-webapp/src/main/java/org/webcurator/rest/dto/TargetDTO.java
@@ -27,7 +27,6 @@ public class TargetDTO {
     @Valid
     List<Seed> seeds = new ArrayList<>();
     @Valid
-    @NotNull
     Profile profile;
     @Valid
     Annotations annotations;
@@ -46,7 +45,9 @@ public class TargetDTO {
         for (org.webcurator.domain.model.core.Seed s : target.getSeeds()) {
             seeds.add(new Seed(s));
         }
-        profile = new Profile(target);
+        if (target.getProfile() != null) {
+            profile = new Profile(target);
+        }
         annotations = new Annotations(target);
         description = new Description(target);
         for (GroupMember m: target.getParents()) {

--- a/webcurator-webapp/src/main/java/org/webcurator/rest/dto/TargetDTO.java
+++ b/webcurator-webapp/src/main/java/org/webcurator/rest/dto/TargetDTO.java
@@ -27,6 +27,7 @@ public class TargetDTO {
     @Valid
     List<Seed> seeds = new ArrayList<>();
     @Valid
+    @NotNull
     Profile profile;
     @Valid
     Annotations annotations;


### PR DESCRIPTION
This PR adds extra attributes to the /harvest-authorisations and /targets endpoints, in order to reduce the number of requests needed to render the corresponding pages in the UI.