### PR TITLE
Improve the performance of the query api for Target List (Story #175)

### DIFF
--- a/webcurator-core/src/main/java/org/webcurator/domain/model/simple/SimpleAbstractTarget.java
+++ b/webcurator-core/src/main/java/org/webcurator/domain/model/simple/SimpleAbstractTarget.java
@@ -1,0 +1,201 @@
+package org.webcurator.domain.model.simple;
+
+import org.webcurator.domain.UserOwnable;
+import org.webcurator.domain.model.auth.User;
+
+import javax.validation.constraints.Size;
+import javax.validation.constraints.NotNull;
+import javax.persistence.*;
+import java.util.*;
+
+/**
+ * Base Target object to capture the common behaviour between groups and
+ * targets.
+ *
+ * @author bbeaumont
+ */
+// lazy="true"
+@SuppressWarnings("all")
+@Entity
+@Table(name = "ABSTRACT_TARGET")
+@Inheritance(strategy = InheritanceType.JOINED)
+public abstract class SimpleAbstractTarget implements UserOwnable {
+    /**
+     * the primary key of the Target.
+     */
+    @Id
+    @NotNull
+    @Column(name = "AT_OID")
+    // Note: From the Hibernate 4.2 documentation:
+    // The Hibernate team has always felt such a construct as fundamentally wrong.
+    // Try hard to fix your data model before using this feature.
+    @TableGenerator(name = "SharedTableIdGenerator",
+            table = "ID_GENERATOR",
+            pkColumnName = "IG_TYPE",
+            valueColumnName = "IG_VALUE",
+            pkColumnValue = "General",
+            allocationSize = 1) // 50 is the default
+    @GeneratedValue(strategy = GenerationType.TABLE, generator = "SharedTableIdGenerator")
+    private Long oid;
+    /**
+     * The targets name.
+     */
+    @Size(max = 255)
+    @Column(name = "AT_NAME")
+    private String name;
+    /**
+     * the targets description.
+     */
+    @Size(max = 4000)
+    @Column(name = "AT_DESC")
+    private String description;
+
+    /**
+     * Owner of the target
+     **/
+    @ManyToOne
+    @JoinColumn(name = "AT_OWNER_ID")
+    private User owner;
+
+    /**
+     * The loaded state of the target
+     **/
+    @Transient
+    private int originalState = -1;
+    /**
+     * The state of the target
+     **/
+    @Column(name = "AT_STATE")
+    private int state;
+
+    /**
+     * The date the Target was created
+     */
+    @Column(name = "AT_CREATION_DATE")
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date creationDate;
+    /**
+     * The parents of this group
+     */
+    @OneToMany(orphanRemoval = true) // default fetch type is LAZY
+    @JoinColumn(name = "GM_CHILD_ID")
+    private Set<SimpleGroupMember> parents = new HashSet<SimpleGroupMember>();
+
+    /**
+     * Identifies whether this is a target or group without needing to use
+     * the instanceof operator, which can be important if the object is not
+     * fully initialised by Hibernate.
+     */
+    @Column(name = "AT_OBJECT_TYPE")
+    protected int objectType;
+
+
+    @Column(name = "AT_DISPLAY_TARGET")
+    private boolean displayTarget = true;
+
+
+    /**
+     * Base constructor to prevent no-arg instantiation.
+     */
+    protected SimpleAbstractTarget() {
+    }
+
+
+    /**
+     * Constructor that sets the Object type.
+     *
+     * @param objectType Either TYPE_TARGET or TYPE_GROUP
+     */
+    protected SimpleAbstractTarget(int objectType) {
+        this.objectType = objectType;
+    }
+
+    public @NotNull Long getOid() {
+        return oid;
+    }
+
+    public void setOid(@NotNull Long oid) {
+        this.oid = oid;
+    }
+
+    public @Size(max = 255) String getName() {
+        return name;
+    }
+
+    public void setName(@Size(max = 255) String name) {
+        this.name = name;
+    }
+
+    public @Size(max = 4000) String getDescription() {
+        return description;
+    }
+
+    public void setDescription(@Size(max = 4000) String description) {
+        this.description = description;
+    }
+
+    public User getOwner() {
+        return owner;
+    }
+
+    public void setOwner(User owner) {
+        this.owner = owner;
+    }
+
+    public int getOriginalState() {
+        return originalState;
+    }
+
+    public void setOriginalState(int originalState) {
+        this.originalState = originalState;
+    }
+
+    public int getState() {
+        return state;
+    }
+
+    public void setState(int state) {
+        this.state = state;
+    }
+
+    public Date getCreationDate() {
+        return creationDate;
+    }
+
+    public void setCreationDate(Date creationDate) {
+        this.creationDate = creationDate;
+    }
+
+    public Set<SimpleGroupMember> getParents() {
+        return parents;
+    }
+
+    public void setParents(Set<SimpleGroupMember> parents) {
+        this.parents = parents;
+    }
+
+    public int getObjectType() {
+        return objectType;
+    }
+
+    public void setObjectType(int objectType) {
+        this.objectType = objectType;
+    }
+
+    public boolean isDisplayTarget() {
+        return displayTarget;
+    }
+
+    public void setDisplayTarget(boolean displayTarget) {
+        this.displayTarget = displayTarget;
+    }
+
+    /**
+     * Gets the owner of the AbstractTarget
+     *
+     * @return The owner of the AbstractTarget.
+     */
+    public User getOwningUser() {
+        return owner;
+    }
+}

--- a/webcurator-core/src/main/java/org/webcurator/domain/model/simple/SimpleGroupMember.java
+++ b/webcurator-core/src/main/java/org/webcurator/domain/model/simple/SimpleGroupMember.java
@@ -1,0 +1,77 @@
+package org.webcurator.domain.model.simple;
+
+import javax.validation.constraints.NotNull;
+import javax.persistence.*;
+
+
+/**
+ * Represents a child/parent relationship between an AbstractTarget and a
+ * TargetGroup.
+ *
+ * @author bbeaumont
+ */
+@Entity
+@Table(name = "GROUP_MEMBER")
+public class SimpleGroupMember {
+    /**
+     * The database oid
+     */
+    @Id
+    @NotNull
+    @Column(name = "AT_OID")
+    // Note: From the Hibernate 4.2 documentation:
+    // The Hibernate team has always felt such a construct as fundamentally wrong.
+    // Try hard to fix your data model before using this feature.
+    @TableGenerator(name = "SharedTableIdGenerator",
+            table = "ID_GENERATOR",
+            pkColumnName = "IG_TYPE",
+            valueColumnName = "IG_VALUE",
+            pkColumnValue = "General",
+            allocationSize = 1) // 50 is the default
+    @GeneratedValue(strategy = GenerationType.TABLE, generator = "SharedTableIdGenerator")
+    private Long oid = null;
+    /**
+     * The parent of the member
+     */
+    @ManyToOne
+    @JoinColumn(name = "GM_PARENT_ID")
+    private SimpleTargetGroup parent = null;
+
+    /**
+     * Get the OID of the GroupMember.
+     *
+     * @return Returns the oid.
+     */
+    public Long getOid() {
+        return oid;
+    }
+
+    /**
+     * Set the OID of the GroupMember.
+     *
+     * @param aOid The oid to set.
+     */
+    public void setOid(Long aOid) {
+        this.oid = aOid;
+    }
+
+    /**
+     * Get the parent of the relationship.
+     *
+     * @return Returns the parent.
+     */
+    public SimpleTargetGroup getParent() {
+        return parent;
+    }
+
+    /**
+     * Set the parent of the relationship.
+     *
+     * @param parent The parent to set.
+     */
+    public void setParent(SimpleTargetGroup parent) {
+        this.parent = parent;
+    }
+
+}
+

--- a/webcurator-core/src/main/java/org/webcurator/domain/model/simple/SimpleSeed.java
+++ b/webcurator-core/src/main/java/org/webcurator/domain/model/simple/SimpleSeed.java
@@ -1,0 +1,120 @@
+package org.webcurator.domain.model.simple;
+
+
+import javax.validation.constraints.Size;
+import javax.validation.constraints.NotNull;
+import javax.persistence.*;
+
+@Entity
+@Table(name = "SEED")
+public class SimpleSeed {
+    /**
+     * The unique ID of the seed
+     **/
+    @Id
+    @NotNull
+    @Column(name = "S_OID")
+    // Note: From the Hibernate 4.2 documentation:
+    // The Hibernate team has always felt such a construct as fundamentally wrong.
+    // Try hard to fix your data model before using this feature.
+    @TableGenerator(name = "SharedTableIdGenerator",
+            table = "ID_GENERATOR",
+            pkColumnName = "IG_TYPE",
+            valueColumnName = "IG_VALUE",
+            pkColumnValue = "General",
+            allocationSize = 1) // 50 is the default
+    @GeneratedValue(strategy = GenerationType.TABLE, generator = "SharedTableIdGenerator")
+    private Long oid;
+    /**
+     * The seed itself
+     **/
+    @Size(max = 1024)
+    @Column(name = "S_SEED")
+    private String seed;
+
+    /**
+     * The seed's target
+     **/
+    @Column(name = "S_TARGET_ID")
+    private long targetId;
+
+    /**
+     * Sets if the seed is primary or secondary.
+     */
+    @Column(name = "S_PRIMARY")
+    private boolean primary;
+
+    /**
+     * Protected constructor to prevent instantiation by non-application
+     * components. This class should be instantiated by the
+     * BusinessObjectFactory.
+     */
+    protected SimpleSeed() {
+    }
+
+
+    /**
+     * Returns the database OID of the seed.
+     *
+     * @return Returns the oid.
+     */
+    public Long getOid() {
+        return oid;
+    }
+
+    /**
+     * Set the OID of the seed.
+     *
+     * @param anOid The OID.
+     */
+    public void setOid(Long anOid) {
+        this.oid = anOid;
+    }
+
+    /**
+     * Gets the seed URL.
+     *
+     * @return Returns the seed.
+     */
+    public String getSeed() {
+        return seed;
+    }
+
+
+    /**
+     * Sets the Seed URL.
+     *
+     * @param seed The seed to set.
+     */
+    public void setSeed(String seed) {
+        this.seed = seed;
+    }
+
+    public long getTargetId() {
+        return targetId;
+    }
+
+    public void setTargetId(long targetId) {
+        this.targetId = targetId;
+    }
+
+
+    /**
+     * Checks if the seed is defined as a primary seed.
+     *
+     * @return true if primary; otherwise false.
+     */
+    public boolean isPrimary() {
+        return primary;
+    }
+
+
+    /**
+     * Sets whether this seed should be primary.
+     *
+     * @param primary true to set as primary; otherwise false.
+     */
+    public void setPrimary(boolean primary) {
+        this.primary = primary;
+    }
+}

--- a/webcurator-core/src/main/java/org/webcurator/domain/model/simple/SimpleTarget.java
+++ b/webcurator-core/src/main/java/org/webcurator/domain/model/simple/SimpleTarget.java
@@ -1,0 +1,290 @@
+package org.webcurator.domain.model.simple;
+
+/*
+ *  Copyright 2006 The National Library of New Zealand
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+
+import org.webcurator.domain.model.core.Optimizable;
+import org.webcurator.domain.model.core.Target;
+
+import javax.validation.constraints.Size;
+import javax.persistence.*;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * A Target is a set of seeds, schedules and profile overrides that specify
+ * what to harvest, at what times, and what harvest profile to use.
+ *
+ * @author nwaight
+ */
+// TODO lazy="false"
+@Entity
+@Table(name = "TARGET")
+@PrimaryKeyJoinColumn(name = "T_AT_OID", referencedColumnName = "AT_OID")
+public class SimpleTarget extends SimpleAbstractTarget implements Optimizable {
+
+    /**
+     * Date at which the target was first nominated or approved
+     */
+    @Column(name = "T_SELECTION_DATE")
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date selectionDate;
+    /**
+     * The type of the selection
+     */
+    @Size(max = 255)
+    @Column(name = "T_SELECTION_TYPE")
+    private String selectionType;
+    /**
+     * A selection note
+     */
+    @Size(max = 1000)
+    @Column(name = "T_SELECTION_NOTE")
+    private String selectionNote;
+    /**
+     * An evaluation note
+     */
+    @Size(max = 1000)
+    @Column(name = "T_EVALUATION_NOTE")
+    private String evaluationNote;
+    /**
+     * The type of harvest
+     */
+    @Size(max = 255)
+    @Column(name = "T_HARVEST_TYPE")
+    private String harvestType;
+    /**
+     * The seeds.
+     **/
+    @OneToMany(cascade = {CascadeType.ALL}, orphanRemoval = true) // default fetch type is LAZY
+    @JoinColumn(name = "S_TARGET_ID")
+    private Set<SimpleSeed> seeds = new HashSet<>();
+
+    /**
+     * Run the target as soon as approved
+     */
+    @Column(name = "T_RUN_ON_APPROVAL")
+    private boolean runOnApproval = false;
+
+    /**
+     * Use Automated Quality Assurance on Harvests derived from this Target
+     */
+    @Column(name = "T_USE_AQA")
+    private boolean useAQA = false;
+
+    /**
+     * Run the target in five minutes
+     */
+    @Transient
+    private boolean harvestNow = false;
+    @Column(name = "T_ALLOW_OPTIMIZE")
+    private boolean allowOptimize;
+
+    /**
+     * Protected constructor - all instances should be created through the
+     * <code>BusinessObjectFactory</code>.
+     */
+    public SimpleTarget() {
+        super(Target.TYPE_TARGET);
+    }
+
+    /**
+     * Return the Set of Seeds attached to this target.
+     *
+     * @return Returns the seeds.
+     */
+    public Set<SimpleSeed> getSeeds() {
+        return seeds;
+    }
+
+    /**
+     * Set the set of seeds in this target.
+     *
+     * @param seeds The seeds to set.
+     */
+    public void setSeeds(Set<SimpleSeed> seeds) {
+        this.seeds = seeds;
+    }
+
+
+    /**
+     * Is the target now schedulable?
+     *
+     * @return True if the new state of the target is schedulable.
+     */
+    public boolean isSchedulable() {
+        return Target.isScheduleableState(getState());
+    }
+
+    /**
+     * Was the target schedulable when initialised?
+     *
+     * @return True if the original state was schedulable.
+     */
+    public boolean wasSchedulable() {
+        return Target.isScheduleableState(getOriginalState());
+    }
+
+
+    /**
+     * Checks if the specified state is schedulable - i.e. should the target
+     * have target instances.
+     *
+     * @param aState The state to test.
+     * @return true if schedulable; otherwise false.
+     */
+    public static boolean isScheduleableState(int aState) {
+        return aState == Target.STATE_APPROVED || aState == Target.STATE_COMPLETED;
+    }
+
+
+    /**
+     * @return Returns the runOnApproval.
+     */
+    public boolean isRunOnApproval() {
+        return runOnApproval;
+    }
+
+
+    /**
+     * @param runOnApproval The runOnApproval to set.
+     */
+    public void setRunOnApproval(boolean runOnApproval) {
+        this.runOnApproval = runOnApproval;
+    }
+
+    /**
+     * @return Returns the useAQA.
+     */
+    public boolean isUseAQA() {
+        return useAQA;
+    }
+
+
+    /**
+     * @param useAQA The useAQA to set.
+     */
+    public void setUseAQA(boolean useAQA) {
+        this.useAQA = useAQA;
+    }
+
+
+    /**
+     * @return Returns the evaluationNote.
+     */
+    public String getEvaluationNote() {
+        return evaluationNote;
+    }
+
+
+    /**
+     * @param evaluationNote The evaluationNote to set.
+     */
+    public void setEvaluationNote(String evaluationNote) {
+        this.evaluationNote = evaluationNote;
+    }
+
+
+    /**
+     * @return Returns the selectionDate.
+     */
+    public Date getSelectionDate() {
+        return selectionDate;
+    }
+
+
+    /**
+     * @param selectionDate The selectionDate to set.
+     */
+    public void setSelectionDate(Date selectionDate) {
+        this.selectionDate = selectionDate;
+    }
+
+
+    /**
+     * @return Returns the selectionNote.
+     */
+    public String getSelectionNote() {
+        return selectionNote;
+    }
+
+
+    /**
+     * @param selectionNote The selectionNote to set.
+     */
+    public void setSelectionNote(String selectionNote) {
+        this.selectionNote = selectionNote;
+    }
+
+
+    /**
+     * @return Returns the selectionType.
+     */
+    public String getSelectionType() {
+        return selectionType;
+    }
+
+
+    /**
+     * @param selectionType The selectionType to set.
+     */
+    public void setSelectionType(String selectionType) {
+        this.selectionType = selectionType;
+    }
+
+    /**
+     * @return Returns the harvestType.
+     */
+    public String getHarvestType() {
+        return harvestType;
+    }
+
+    /**
+     * @param harvestType The harvestType to set.
+     */
+    public void setHarvestType(String harvestType) {
+        this.harvestType = harvestType;
+    }
+
+    /**
+     * @return Returns the harvestNow.
+     */
+    public boolean isHarvestNow() {
+        return harvestNow;
+    }
+
+
+    /**
+     * @param harvestNow The harvestNow to set.
+     */
+    public void setHarvestNow(boolean harvestNow) {
+        this.harvestNow = harvestNow;
+    }
+
+    /**
+     * @return Returns the harvestType.
+     */
+    public boolean isAllowOptimize() {
+        return allowOptimize;
+    }
+
+    public void setAllowOptimize(boolean allowOptimize) {
+        this.allowOptimize = allowOptimize;
+    }
+
+}

--- a/webcurator-core/src/main/java/org/webcurator/domain/model/simple/SimpleTargetGroup.java
+++ b/webcurator-core/src/main/java/org/webcurator/domain/model/simple/SimpleTargetGroup.java
@@ -1,0 +1,195 @@
+package org.webcurator.domain.model.simple;
+
+
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.webcurator.core.util.WctUtils;
+import org.webcurator.domain.model.core.AbstractTarget;
+
+import javax.persistence.*;
+import javax.validation.constraints.Size;
+
+/**
+ * A TargetGroup contains a number of child targets or target groups.
+ */
+// TODO lazy="true"
+@Entity
+@Table(name = "TARGET_GROUP")
+@PrimaryKeyJoinColumn(name = "TG_AT_OID", referencedColumnName = "AT_OID")
+public class SimpleTargetGroup extends SimpleAbstractTarget {
+
+    /** The maximum length of the type field. */
+    public static final int MAX_TYPE_LENGTH = 255;
+
+    /** The TargetGroup is Active - at least one child can be scheduled */
+    public static final int STATE_ACTIVE = 9;
+    /** The TargetGroup is inactive - the TargetGroup has reached its end date or all of its children have reached their end dates */
+    public static final int STATE_INACTIVE = 10;
+    /** The TargetGroup is Pending - none of its children are active */
+    public static final int STATE_PENDING = 8;
+
+    /** The type constant for a One SIP group - a group that gets harvested as a single target instance */
+    public static final int ONE_SIP = 1;
+    /** The type constant for a Many SIP group - a group that results in creating a target instance per child */
+    public static final int MANY_SIP = 2;
+
+    /** The type of the Group; one sip or many sip */
+    @Column(name = "TG_SIP_TYPE")
+    private int sipType = ONE_SIP;
+    /** Date at which the Group's membership starts for meta-data purposes. */
+    @Column(name = "TG_START_DATE")
+    @Temporal(TemporalType.DATE)
+    private Date fromDate = null;
+    /** Date at which the Group's membership ends for meta-data purposes. */
+    @Column(name = "TG_END_DATE")
+    @Temporal(TemporalType.DATE)
+    private Date toDate   = null;
+    /** The ownership meta data. */
+    @Size(max=255)
+    @Column(name = "TG_OWNERSHIP_METADATA")
+    private String ownershipMetaData = null;
+    /** Children */
+    @OneToMany // default fetch type is LAZY
+    @JoinColumn(name = "GM_PARENT_ID")
+    private Set<SimpleGroupMember> children = new HashSet<>();
+
+    /** The type of the group */
+    @Size(max=255)
+    @Column(name = "TG_TYPE")
+    private String type;
+
+    /**
+     * Protected constructor to ensure instantiation is through the 
+     * BusinessObjectFactory.
+     */
+    protected SimpleTargetGroup() {
+        super(AbstractTarget.TYPE_GROUP);
+    }
+
+    /* (non-Javadoc)
+     * @see org.webcurator.domain.model.simple.AbstractTarget#getSeeds()
+     */
+    public Set<SimpleSeed> getSeeds() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    /**
+     * Gets whether the TargetGroup is one SIP or many SIP.
+     * @return Returns the type - either ONE_SIP or MANY_SIP.
+     */
+    public int getSipType() {
+        return sipType;
+    }
+
+    /**
+     * Sets whether the TargetGroup is ONE_SIP or MANY_SIP.
+     * @param type The type to set.
+     */
+    public void setSipType(int type) {
+        this.sipType = type;
+    }
+
+    /**
+     * Get the date that the group becomes active.
+     * @return Returns the fromDate.
+     */
+    public Date getFromDate() {
+        return fromDate;
+    }
+
+    /**
+     * Set the date the group becomes active.
+     * @param fromDate The fromDate to set.
+     */
+    public void setFromDate(Date fromDate) {
+        if(fromDate == null) {
+            this.fromDate = null;
+        }
+        else {
+            this.fromDate = WctUtils.clearTime(fromDate);
+        }
+    }
+
+    /**
+     * Get the date the group becomes inactive.
+     * @return Returns the toDate.
+     */
+    public Date getToDate() {
+        return toDate;
+    }
+
+    /**
+     * Set the date the group becomes inactive.
+     * @param toDate The toDate to set.
+     */
+    public void setToDate(Date toDate) {
+        if(toDate == null) {
+            this.toDate = null;
+        }
+        else {
+            this.toDate = WctUtils.endOfDay(toDate);
+        }
+    }
+
+    /**
+     * Get the ownership Meta Data for the TargetGroup. This allows additional
+     * information about ownership to be added to the group, which is important
+     * since a group can only have a single owner.
+     *
+     * @return Returns the ownerhsipMetaData.
+     */
+    public String getOwnershipMetaData() {
+        return ownershipMetaData;
+    }
+
+    /**
+     * Set the ownership meta data for the TargetGroup.
+     * @see #getOwnershipMetaData()
+     * @param ownerhsipMetaData The ownerhsipMetaData to set.
+     */
+    public void setOwnershipMetaData(String ownerhsipMetaData) {
+        this.ownershipMetaData = ownerhsipMetaData;
+    }
+
+    /**
+     * Gets a set of all the children.
+     * @return Returns the children.
+     */
+    public Set<SimpleGroupMember> getChildren() {
+        return children;
+    }
+
+    /**
+     * Sets the set of children.
+     * @param children The children to set.
+     */
+    public void setChildren(Set<SimpleGroupMember> children) {
+        this.children = children;
+    }
+
+    /**
+     * Is the target now schedulable?
+     * @return True if the new state of the target is schedulable.
+     */
+    public boolean isSchedulable() {
+        return getState() == SimpleTargetGroup.STATE_ACTIVE;
+    }
+
+    /**
+     * @return Returns the type.
+     */
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * @param type The type to set.
+     */
+    public void setType(String type) {
+        this.type = type;
+    }
+
+}

--- a/webcurator-webapp/src/main/java/org/webcurator/rest/Targets.java
+++ b/webcurator-webapp/src/main/java/org/webcurator/rest/Targets.java
@@ -19,6 +19,8 @@ import org.webcurator.domain.*;
 import org.webcurator.domain.model.auth.User;
 import org.webcurator.domain.model.core.*;
 import org.webcurator.domain.model.dto.GroupMemberDTO;
+import org.webcurator.domain.model.simple.SimpleSeed;
+import org.webcurator.domain.model.simple.SimpleTarget;
 import org.webcurator.rest.common.BadRequestError;
 import org.webcurator.rest.common.Utils;
 import org.webcurator.rest.dto.TargetDTO;
@@ -686,11 +688,11 @@ public class Targets {
         // The TargetDao API only supports offsets that are a multiple of limit
         int pageNumber = offset / limit;
 
-        Pagination pagination = targetDAO.search(pageNumber, limit, filter.targetId, filter.name,
+        Pagination pagination = targetDAO.searchSummary(pageNumber, limit, filter.targetId, filter.name,
                 filter.states, filter.seed, filter.userId, filter.agency, filter.groupName,
                 filter.nonDisplayOnly, magicSortStringForDao, filter.description);
         List<HashMap<String, Object>> targetSummaries = new ArrayList<>();
-        for (Target t : (List<Target>) pagination.getList()) {
+        for (SimpleTarget t : (List<SimpleTarget>) pagination.getList()) {
             targetSummaries.add(getTargetSummary(t));
         }
         return new SearchResult(pagination.getTotal(), targetSummaries);
@@ -699,7 +701,7 @@ public class Targets {
     /**
      * Create the summary target info used for search results
      */
-    private HashMap<String, Object> getTargetSummary(Target t) {
+    private HashMap<String, Object> getTargetSummary(SimpleTarget t) {
         HashMap<String, Object> targetSummary = new HashMap<>();
         targetSummary.put("id", t.getOid());
         targetSummary.put("creationDate", t.getCreationDate());
@@ -708,7 +710,7 @@ public class Targets {
         targetSummary.put("owner", t.getOwner().getUsername());
         targetSummary.put("state", t.getState());
         ArrayList<HashMap<String, Object>> seeds = new ArrayList<>();
-        for (Seed s : t.getSeeds()) {
+        for (SimpleSeed s : t.getSeeds()) {
             HashMap<String, Object> seed = new HashMap<>();
             seed.put("seed", s.getSeed());
             seed.put("primary", s.isPrimary());


### PR DESCRIPTION
Improve the performance of the query api for Target List with the simplified entities:

Create simplified Target entity and the other related entities. Only get the needed columns include in the entities.
Ignore the unnecessary cascade relationships in the entities.
Add a new searchSummary method with the same mechanism as the existing search method.
Call the searchSummary from the Target search api.

See the story: https://github.com/WebCuratorTool/webcurator/issues/175#issue-2885822966