### PR TITLE
Fix #178: Allow individual schedules to be updated

### DIFF
--- a/webcurator-docs/guides/apis/api-target_PUT.rst
+++ b/webcurator-docs/guides/apis/api-target_PUT.rst
@@ -11,7 +11,7 @@ Also the following parts can be updated separately by adding the part name to th
 
 Each part must contain at least one field that needs updating. Only the fields given are updated, fields not given, but present in the database, remain unchanged.
 
-Fields of mutable lists (seeds, schedule.schedules, annotations.annotations, groups) can not be updated individually: if a list is present in the input, the corresponding list attribute of the target will be overwritten with the new list. Fields of profile.overrides, which is a fixed list, can be updated individually.
+The fields of the following lists can not be updated individually: seeds, annotations.annotations, groups. If a list is present in the input for any of these attributes, the corresponding list attribute of the target will be overwritten with the new list. Fields of profile.overrides, which is a fixed list, and schedules in schedule.schedules can be updated individually.
 
 +-------------+
 | **part**    |

--- a/webcurator-docs/guides/apis/descriptions/part-schedule_target.rst
+++ b/webcurator-docs/guides/apis/descriptions/part-schedule_target.rst
@@ -11,7 +11,7 @@ schedules           List    Optional
 =================== ======= ========
 
 | **schedules**
-| A list of schedules that belong to a target containing the following information:
+| A list of schedules that belong to a target. If, upon updating a target, an existing schedule is not supplied, it will be deleted. Supplied schedules that do not match an existing schedule will be added. Each schedule contains the following fields:
 
 ================= ======= ========
 **schedules**
@@ -27,7 +27,7 @@ lastExecutionDate Date    Optional
 ================= ======= ========
 
 | **id**
-.. include:: /guides/apis/descriptions/desc-systemGenerated.rst
+This field is system-generated and may not be given at creation time.
 
 .. include:: /guides/apis/descriptions/desc-cron.rst
 

--- a/webcurator-webapp/src/main/java/org/webcurator/rest/Targets.java
+++ b/webcurator-webapp/src/main/java/org/webcurator/rest/Targets.java
@@ -304,7 +304,6 @@ public class Targets {
         target.setRequestToArchivists(targetDTO.getGeneral().getRequestToArchivists());
 
         if (targetDTO.getSchedule() != null) {
-            Set<Schedule> schedules = new HashSet<>();
             if (targetDTO.getSchedule().getHarvestOptimization() != null) {
                 target.setAllowOptimize(targetDTO.getSchedule().getHarvestOptimization());
             }
@@ -314,30 +313,30 @@ public class Targets {
                 }
                 target.setHarvestNow(targetDTO.getSchedule().getHarvestNow());
             }
+            // Upsert the schedules and distinguish existing ones to be updated from new ones to added
+            ArrayList<Schedule> schedulesToBeDeleted = new ArrayList<>();
+            for (Schedule schedule : target.getSchedules()) {
+                boolean deleteSchedule = true;
+                for (TargetDTO.Scheduling.Schedule s : targetDTO.getSchedule().getSchedules()) {
+                    if (schedule.getOid().equals(s.getId())) {
+                        deleteSchedule = false;
+                        fillSchedule(schedule, s);
+                        targetDTO.getSchedule().getSchedules().remove(s); // keep track of updates
+                        break;
+                    }
+                }
+                // The existing schedule was not found among the supplied schedules: delete it
+                if (deleteSchedule) {
+                    schedulesToBeDeleted.add(schedule);
+                }
+            }
+            target.getSchedules().removeAll(schedulesToBeDeleted);
+            // Any remaining supplied schedules are guaranteed to be new schedules: add them now
             for (TargetDTO.Scheduling.Schedule s : targetDTO.getSchedule().getSchedules()) {
                 Schedule schedule = businessObjectFactory.newSchedule(target);
-                String cronExpression = s.getCron();
-                // we support classic cron, without the prepended SECONDS field expected by Quartz
-                cronExpression = "0 " + s.getCron();
-                try {
-                    new CronExpression(cronExpression);
-                } catch (ParseException ex) {
-                    throw new BadRequestError(String.format("Invalid cron expression: %s", ex.getMessage()));
-                }
-                schedule.setCronPattern(cronExpression);
-                schedule.setStartDate(s.getStartDate());
-                schedule.setEndDate(s.getEndDate());
-                schedule.setScheduleType(s.getType());
-                owner = userRoleDAO.getUserByName(s.getOwner());
-                if (owner == null) {
-                    throw new BadRequestError(String.format("Owner with username %s unknown",
-                            targetDTO.getGeneral().getOwner()));
-                }
-                schedule.setOwningUser(owner);
-                schedules.add(schedule);
+                fillSchedule(schedule, s);
+                target.getSchedules().add(schedule);
             }
-            target.getSchedules().clear();
-            target.getSchedules().addAll(schedules);
         }
 
         if (targetDTO.getAccess() != null) {
@@ -503,6 +502,24 @@ public class Targets {
         }
     }
 
+    private void fillSchedule(Schedule schedule, TargetDTO.Scheduling.Schedule s) throws BadRequestError {
+        // we support classic cron, without the prepended SECONDS field expected by Quartz
+        String cronExpression = "0 " + s.getCron();
+        try {
+            new CronExpression(cronExpression);
+        } catch (ParseException ex) {
+            throw new BadRequestError(String.format("Invalid cron expression: %s", ex.getMessage()));
+        }
+        schedule.setCronPattern(cronExpression);
+        schedule.setStartDate(s.getStartDate());
+        schedule.setEndDate(s.getEndDate());
+        schedule.setScheduleType(s.getType());
+        User owner = userRoleDAO.getUserByName(s.getOwner());
+        if (owner == null) {
+            throw new BadRequestError(String.format("Owner with username %s unknown", s.getOwner()));
+        }
+        schedule.setOwningUser(owner);
+    }
 
     /**
      * Traverses the supplied HashMap recursively, mapping any data it finds to the right setter in the supplied

--- a/webcurator-webapp/src/main/java/org/webcurator/rest/dto/TargetDTO.java
+++ b/webcurator-webapp/src/main/java/org/webcurator/rest/dto/TargetDTO.java
@@ -322,7 +322,7 @@ public class TargetDTO {
         }
 
         public static class Schedule {
-            long id;
+            Long id;
             @NotBlank(message = "cron is required")
             String cron;
             @NotNull(message = "startDate is required")
@@ -341,11 +341,11 @@ public class TargetDTO {
             public Schedule() {
             }
 
-            public long getId() {
+            public Long getId() {
                 return id;
             }
 
-            public void setId(long id) {
+            public void setId(Long id) {
                 this.id = id;
             }
 


### PR DESCRIPTION
The API has been changed so that PUT /targets/<id> now allows you to update individual schedules (by including their id in the "id" attribute). Supplied schedules without an "id" attribute are simply added and existing schedules not present in the supplied schedules will be deleted.

Docs have also been updated to reflect the changes.