### PR TITLE
Add filtering of permissions by harvest authorisation name

### DIFF
--- a/webcurator-docs/guides/apis/api-permission_GET.rst
+++ b/webcurator-docs/guides/apis/api-permission_GET.rst
@@ -24,7 +24,7 @@ startDate                Date    Required
 endDate                  Date    Required
 status                   Integer Required
 urlPatterns              List    Required
-harvestAuthorisationId   Number  Required
+harvestAuthorisation     Object  Required
 accessStatus             String  Required
 copyrightStatement       String  Optional
 copyrightUrl             String  Optional
@@ -36,6 +36,9 @@ annotations              List    Required
 displayName              String  Optional
 exclusions               List    Required
 ======================== ======= ========
+
+| **harvestAuthorisation** 
+| Object containing the id and the name of the harvest authorisation. 
 
 | **authorisingAgent** 
 | Object containing the id and the name of the authorising agent. 

--- a/webcurator-docs/guides/apis/api-permissions_GET.rst
+++ b/webcurator-docs/guides/apis/api-permissions_GET.rst
@@ -73,8 +73,10 @@ startDate               Date    Required
 endDate                 Date    Required
 status                  Integer Required
 urlPatterns             List    Required
-harvestAuthorisationId  Number  Required
+authorisingAgentName    String  Required
+harvestAuthorisation    Object  Required
 ======================= ======= ========
+
 
 Errors
 ------

--- a/webcurator-docs/guides/apis/api-permissions_GET.rst
+++ b/webcurator-docs/guides/apis/api-permissions_GET.rst
@@ -25,12 +25,19 @@ page   Number Optional
 
 Filterable fields are:
 
-========= ====== ========
-targetId  Number Required
-url       String Optional
-========= ====== ========
+======================== ====== ========
+targetId                 Number Required
+url                      String Optional
+harvestAuthorisationName String Optional
+======================== ====== ========
 
-Semantics of the filter: return all permissions having a URL pattern that matches the supplied URL and having the same agency as the owning user of the target (identified by the supplied target id).
+Semantics of the filter:
+
+* if the url parameter has been supplied: return all permissions having a URL pattern that matches the supplied URL and having the same agency as the owning user of the target (identified by the supplied target id).
+
+* if the harvestAuthorisationName parameter has been supplied: return all permissions having a harvest authorisation with a name starting with the supplied value and having the same agency as the owning user of the target (identified by the supplied target id).
+
+* if the filter contains both these parameters, a Bad Request error will be returned.
 
 
 | **page**

--- a/webcurator-webapp/src/main/java/org/webcurator/rest/HarvestAuthorisations.java
+++ b/webcurator-webapp/src/main/java/org/webcurator/rest/HarvestAuthorisations.java
@@ -128,7 +128,7 @@ public class HarvestAuthorisations {
         if (offset < 0) {
             throw new BadRequestError("Offset may not be negative");
         }
-        // The TargetDao API only supports offsets that are a multiple of limit
+        // The SiteDao API only supports offsets that are a multiple of limit
         int pageNumber = offset / limit;
 
         SiteCriteria criteria = new SiteCriteria();

--- a/webcurator-webapp/src/main/java/org/webcurator/rest/Permissions.java
+++ b/webcurator-webapp/src/main/java/org/webcurator/rest/Permissions.java
@@ -70,6 +70,7 @@ public class Permissions {
                 urls.add(u.getPattern());
            }
            permission.put("urlPatterns", urls);
+           permission.put("authorisingAgentName", p.getAuthorisingAgent().getName());
            HashMap<String, Object> harvestAuthorisation = new HashMap<>();
            harvestAuthorisation.put("id", p.getSite().getOid());
            harvestAuthorisation.put("name", p.getSite().getTitle());

--- a/webcurator-webapp/src/main/java/org/webcurator/rest/Permissions.java
+++ b/webcurator-webapp/src/main/java/org/webcurator/rest/Permissions.java
@@ -70,7 +70,10 @@ public class Permissions {
                 urls.add(u.getPattern());
            }
            permission.put("urlPatterns", urls);
-           permission.put("harvestAuthorisationId", p.getSite().getOid());
+           HashMap<String, Object> harvestAuthorisation = new HashMap<>();
+           harvestAuthorisation.put("id", p.getSite().getOid());
+           harvestAuthorisation.put("name", p.getSite().getTitle());
+           permission.put("harvestAuthorisation", harvestAuthorisation);
            permissions.add(permission);
        }
 

--- a/webcurator-webapp/src/main/java/org/webcurator/rest/Permissions.java
+++ b/webcurator-webapp/src/main/java/org/webcurator/rest/Permissions.java
@@ -1,5 +1,6 @@
 package org.webcurator.rest;
 
+import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -36,6 +37,11 @@ public class Permissions {
           return ResponseEntity.badRequest().body(Utils.errorMessage("Expected a filter parameter with 'targetId' field"));
        }
 
+       if (StringUtils.isNotEmpty(filter.url)  && StringUtils.isNotEmpty(filter.harvestAuthorisationName)) {
+           return ResponseEntity.badRequest().body(Utils.errorMessage("Filter parameters 'url' and 'harvestAuthorisationName' " +
+                                                                                            "may not both be present"));
+       }
+
        Target target = targetManager.load(filter.targetId, true);
        if (target == null) {
            return ResponseEntity.badRequest().body(Utils.errorMessage(String.format("Target %d does not exist",
@@ -44,7 +50,11 @@ public class Permissions {
 
        Pagination pagination;
        try {
-           pagination = targetManager.findPermissionsByUrl(target, filter.url, searchParams.getPage());
+           if (StringUtils.isNotEmpty(filter.url)) {
+               pagination = targetManager.findPermissionsByUrl(target, filter.url, searchParams.getPage());
+           } else { // if harvestAuthorisationName is empty as well, this will return all harvest authorisations
+               pagination = targetManager.findPermissionsBySiteTitle(target, filter.harvestAuthorisationName, searchParams.getPage());
+           }
        } catch (Exception e) {
            return ResponseEntity.internalServerError().body(Utils.errorMessage(e.getMessage()));
        }
@@ -118,6 +128,7 @@ public class Permissions {
     private static class Filter {
         private Long targetId;
         private String url = "";
+        private String harvestAuthorisationName = "";
 
         public Long getTargetId() {
             return targetId;
@@ -133,6 +144,14 @@ public class Permissions {
 
         public void setUrl(String url) {
             this.url = url;
+        }
+
+        public String getHarvestAuthorisationName() {
+            return harvestAuthorisationName;
+        }
+
+        public void setHarvestAuthorisationName(String harvestAuthorisationName) {
+            this.harvestAuthorisationName = harvestAuthorisationName;
         }
     }
 

--- a/webcurator-webapp/src/main/java/org/webcurator/rest/dto/PermissionDTO.java
+++ b/webcurator-webapp/src/main/java/org/webcurator/rest/dto/PermissionDTO.java
@@ -1,8 +1,6 @@
 package org.webcurator.rest.dto;
 
-import org.webcurator.domain.model.core.Permission;
-import org.webcurator.domain.model.core.PermissionExclusion;
-import org.webcurator.domain.model.core.UrlPattern;
+import org.webcurator.domain.model.core.*;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -14,7 +12,7 @@ public class PermissionDTO {
     private Date endDate;
     private Integer status;
     private List<String> urlPatterns;
-    private Long harvestAuthorisationId;
+    private HarvestAuthorisation harvestAuthorisation;
     private String accessStatus;
     private String copyrightStatement;
     private String copyRightUrl;
@@ -37,7 +35,12 @@ public class PermissionDTO {
         for (UrlPattern p : permission.getUrls()) {
             urlPatterns.add(p.getPattern());
         }
+<<<<<<< HEAD
         harvestAuthorisationId = permission.getSite().getOid();
+=======
+        authorisingAgent = new AuthorisingAgent(permission.getAuthorisingAgent());
+        harvestAuthorisation = new HarvestAuthorisation(permission.getSite());
+>>>>>>> 0b019454 (Add harvestAuthorisation object to GET /permissions/<id> response)
         accessStatus = permission.getAccessStatus();
         copyrightStatement = permission.getCopyrightStatement();
         copyRightUrl = permission.getCopyrightUrl();
@@ -100,14 +103,6 @@ public class PermissionDTO {
 
     public void setUrlPatterns(List<String> urlPatterns) {
         this.urlPatterns = urlPatterns;
-    }
-
-    public Long getHarvestAuthorisationId() {
-        return harvestAuthorisationId;
-    }
-
-    public void setHarvestAuthorisationId(Long harvestAuthorisationId) {
-        this.harvestAuthorisationId = harvestAuthorisationId;
     }
 
     public String getAccessStatus() {
@@ -188,6 +183,40 @@ public class PermissionDTO {
 
     public void setExclusions(List<Exclusion> exclusions) {
         this.exclusions = exclusions;
+    }
+
+    public HarvestAuthorisation getHarvestAuthorisation() {
+        return harvestAuthorisation;
+    }
+
+    public void setHarvestAuthorisation(HarvestAuthorisation harvestAuthorisation) {
+        this.harvestAuthorisation = harvestAuthorisation;
+    }
+
+    public static class HarvestAuthorisation {
+        Long id;
+        String name;
+
+        public HarvestAuthorisation(Site site) {
+            id = site.getOid();
+            name = site.getTitle();
+        }
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
     }
 
     public static class Exclusion {

--- a/webcurator-webapp/src/main/java/org/webcurator/rest/dto/PermissionDTO.java
+++ b/webcurator-webapp/src/main/java/org/webcurator/rest/dto/PermissionDTO.java
@@ -35,12 +35,8 @@ public class PermissionDTO {
         for (UrlPattern p : permission.getUrls()) {
             urlPatterns.add(p.getPattern());
         }
-<<<<<<< HEAD
-        harvestAuthorisationId = permission.getSite().getOid();
-=======
         authorisingAgent = new AuthorisingAgent(permission.getAuthorisingAgent());
         harvestAuthorisation = new HarvestAuthorisation(permission.getSite());
->>>>>>> 0b019454 (Add harvestAuthorisation object to GET /permissions/<id> response)
         accessStatus = permission.getAccessStatus();
         copyrightStatement = permission.getCopyrightStatement();
         copyRightUrl = permission.getCopyrightUrl();
@@ -275,6 +271,11 @@ public class PermissionDTO {
     public static class AuthorisingAgent {
         private Long id;
         private String name;
+
+        public AuthorisingAgent(org.webcurator.domain.model.core.AuthorisingAgent authorisingAgent) {
+            this.id = authorisingAgent.getOid();
+            this.name = authorisingAgent.getName();
+        }
 
         public AuthorisingAgent() {}
 


### PR DESCRIPTION
This implements story #172. I've added a filter parameter 'harvestAuthorisationName' to GET /permissions, that allows searching for permissions having a harvest authorisation with a name that starts with the supplied value. I've also updated the API documentation.