### PR TITLE
Add optional retrieval of target instance annotations to TI search

### DIFF
--- a/webcurator-docs/guides/apis/api-target_instances_GET.rst
+++ b/webcurator-docs/guides/apis/api-target_instances_GET.rst
@@ -14,12 +14,13 @@ Body
 ^^^^
 .. include:: /guides/apis/descriptions/desc-query-method.rst
 
-====== ====== ========
-filter String Optional
-sortBy String Optional
-offset Number Optional
-limit  Number Optional
-====== ====== ========
+================== ======= ========
+filter             String  Optional
+sortBy             String  Optional
+offset             Number  Optional
+limit              Number  Optional
+includeAnnotations Boolean Optional
+================== ======= ========
 
 | **filter**
 | Name of field upon which the result set must be filtered. Only filterable fields maybe given, others are ignored. Filterable fields are:
@@ -33,7 +34,7 @@ limit  Number Optional
 * name [contains text]
 * flagId [exact match only]
 * nonDisplayOnly [Boolean]
-* state [List of integers, exact match only]
+* states [List of integers, exact match only]
 * qaRecommendation [List of strings, exact match only]
 
 | Multiple filter fields may be given, but each field only once. If a filter field is given multiple times this will result in an error.
@@ -65,6 +66,9 @@ Only one sort field may be given as input. If multiple sort fields are given the
 .. include:: /guides/apis/descriptions/desc-request-offset.rst
 
 .. include:: /guides/apis/descriptions/desc-request-limit.rst
+
+| **includeAnnotations**
+| If true, return the annotations for every target instance (default false).
 
 Response
 --------

--- a/webcurator-docs/guides/apis/descriptions/desc-request-limit.rst
+++ b/webcurator-docs/guides/apis/descriptions/desc-request-limit.rst
@@ -6,4 +6,4 @@
  
 This is the maximum amount of rows shown on a results page.
 
-If '0' or less is given as limit then all rows that meet the filter criteria are returned. 
+If '-1' is given as limit then all rows that meet the filter criteria are returned. 

--- a/webcurator-webapp/src/main/java/org/webcurator/rest/TargetInstances.java
+++ b/webcurator-webapp/src/main/java/org/webcurator/rest/TargetInstances.java
@@ -553,8 +553,8 @@ public class TargetInstances {
             }
         }
 
-        if (limit < 1) {
-            throw new BadRequestError("Limit must be positive");
+        if (limit < -1 || limit == 0) {
+            throw new BadRequestError("Limit must be positive or -1 (no limit)");
         }
         if (offset < 0) {
             throw new BadRequestError("Offset may not be negative");
@@ -582,12 +582,21 @@ public class TargetInstances {
         targetInstanceCriteria.setFlag(flag);
         targetInstanceCriteria.setTargetSearchOid(filter.targetId);
         targetInstanceCriteria.setSortorder(magicSortStringForDao);
-        Pagination pagination = targetInstanceDAO.search(targetInstanceCriteria, pageNumber, limit);
+        List<TargetInstance> result;
+        long total;
+        if (limit == -1) { // return all results without paging
+            result = targetInstanceDAO.search(targetInstanceCriteria);
+            total = result.size();
+        } else {
+            Pagination pagination = targetInstanceDAO.search(targetInstanceCriteria, pageNumber, limit);
+            result = pagination.getList();
+            total = pagination.getTotal();
+        }
         List<HashMap<String, Object>> targetInstanceSummaries = new ArrayList<>();
-        for (TargetInstance t : (List<TargetInstance>) pagination.getList()) {
+        for (TargetInstance t : result) {
             targetInstanceSummaries.add(getTargetInstanceSummary(t, includeAnnotations));
         }
-        return new SearchResult(pagination.getTotal(), targetInstanceSummaries);
+        return new SearchResult(total, targetInstanceSummaries);
     }
 
     /**


### PR DESCRIPTION
This change adds a boolean search parameter "includeAnnotations" to the target-instances endpoint. E.g.

`curl -XGET -H"Content-Type: application/json" -H"Authorization: Bearer <token>" http://localhost:8080/wct/api/v1/target-instances/ -d'{"filter" : {"states" : [5]}, "includeAnnotations" : true, "limit" : 10, "sortBy" : "harvestDate,desc"}'
`

@jeremy-liss, would this work as an implementation of #193? 